### PR TITLE
add intrinsic system: unsafe.{bit_cast,ptr_cast,ptr_load,ptr_store}

### DIFF
--- a/Birdee/Birdee.vcxproj
+++ b/Birdee/Birdee.vcxproj
@@ -194,6 +194,7 @@
   <ItemGroup>
     <Text Include="..\BirdeeHome\src\functional.txt" />
     <Text Include="..\BirdeeHome\src\unsafe.txt" />
+    <Text Include="..\BirdeeHome\src\variant.txt" />
     <Text Include="..\BirdeeHome\src\vector.txt" />
     <Text Include="..\BirdeeHome\src\birdee.txt" />
     <Text Include="..\BirdeeHome\src\compile_name_checking_test.txt" />

--- a/Birdee/Birdee.vcxproj
+++ b/Birdee/Birdee.vcxproj
@@ -193,6 +193,7 @@
   </ItemGroup>
   <ItemGroup>
     <Text Include="..\BirdeeHome\src\functional.txt" />
+    <Text Include="..\BirdeeHome\src\unsafe.txt" />
     <Text Include="..\BirdeeHome\src\vector.txt" />
     <Text Include="..\BirdeeHome\src\birdee.txt" />
     <Text Include="..\BirdeeHome\src\compile_name_checking_test.txt" />

--- a/Birdee/Birdee.vcxproj.filters
+++ b/Birdee/Birdee.vcxproj.filters
@@ -145,6 +145,9 @@
     <Text Include="..\BirdeeHome\src\functional.txt">
       <Filter>资源文件\blib</Filter>
     </Text>
+    <Text Include="..\BirdeeHome\src\unsafe.txt">
+      <Filter>资源文件\blib</Filter>
+    </Text>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\tests\ast_write_test.py">

--- a/Birdee/Birdee.vcxproj.filters
+++ b/Birdee/Birdee.vcxproj.filters
@@ -148,6 +148,9 @@
     <Text Include="..\BirdeeHome\src\unsafe.txt">
       <Filter>资源文件\blib</Filter>
     </Text>
+    <Text Include="..\BirdeeHome\src\variant.txt">
+      <Filter>资源文件\blib</Filter>
+    </Text>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\tests\ast_write_test.py">

--- a/Birdee/CopyAST.cpp
+++ b/Birdee/CopyAST.cpp
@@ -173,7 +173,9 @@ namespace Birdee
 		{
 			args.push_back(ToExpr(arg->Copy()));
 		}
-		return SetPos(make_unique<CallExprAST>(ToExpr(Callee->Copy()), std::move(args)),Pos);
+		auto ret = make_unique<CallExprAST>(ToExpr(Callee->Copy()), std::move(args));
+		ret->func_callee = func_callee;
+		return SetPos(std::move(ret),Pos);
 	}
 
 	std::unique_ptr<StatementAST> Birdee::VariableSingleDefAST::Copy()

--- a/Birdee/Intrinsics.cpp
+++ b/Birdee/Intrinsics.cpp
@@ -1,0 +1,184 @@
+#include "BdAST.h"
+#include "CompileError.h"
+#include "llvm/IR/IRBuilder.h"
+
+
+extern llvm::IRBuilder<> builder;
+
+#define CompileAssert(a, p ,msg)\
+do\
+{\
+	if (!(a))\
+	{\
+		throw CompileError(p, msg);\
+	}\
+}while(0)\
+
+namespace Birdee
+{
+	extern llvm::Type* GetLLVMTypeFromResolvedType(const ResolvedType& ty);
+	extern int GetLLVMTypeSizeInBit(llvm::Type* ty);
+
+	static void CheckIntrinsic(FunctionAST* func, int arg_num, int targ_num)
+	{
+		CompileAssert(func->isTemplateInstance, func->Pos, "The intrinsic function should be a template instance");
+		CompileAssert(func->Proto->resolved_args.size() == arg_num, func->Pos, "Wrong number of parameters for the intrinsic function");
+		CompileAssert(func->template_instance_args->size() == targ_num, func->Pos, "Wrong number of template parameters for the intrinsic function");
+	}
+
+	static void Intrinsic_UnsafePtrCast_Phase1(FunctionAST* func)
+	{
+		CheckIntrinsic(func, 1, 2);
+		auto& targs = *func->template_instance_args;
+		CompileAssert(targs[0].kind == TemplateArgument::TEMPLATE_ARG_TYPE &&
+			(targs[0].type.isReference() || targs[0].type.type == tok_pointer || targs[0].type.isInteger()), //no need to check index level. it is implied in isReference()
+			func->Pos, "The 1st template argument for unsafe.ptr_cast should be a pointer, reference or integer");
+		CompileAssert(targs[1].kind == TemplateArgument::TEMPLATE_ARG_TYPE &&
+			(targs[1].type.isReference() || targs[1].type.type == tok_pointer || targs[1].type.isInteger()), //no need to check index level. it is implied in isReference()
+			func->Pos, "The 2nd template argument for unsafe.ptr_cast should be a pointer, reference or integer");
+	}
+
+	static void Intrinsic_UnsafePtrLoad_Phase1(FunctionAST* func)
+	{
+		CheckIntrinsic(func, 1, 1);
+		auto& targs = *func->template_instance_args;
+		CompileAssert(targs[0].kind == TemplateArgument::TEMPLATE_ARG_TYPE,
+			func->Pos, "The 1st template argument for unsafe.ptr_load should be a type");
+		auto& arg_t = func->Proto->resolved_args[0]->resolved_type;
+		CompileAssert(arg_t.type == tok_pointer || arg_t.index_level == 0,
+			func->Pos, "The parameter for unsafe.ptr_load should be a pointer");
+	}
+
+
+	static llvm::Value* Intrinsic_UnsafePtrCast_Generate(FunctionAST* func, llvm::Value* obj, vector<unique_ptr<ExprAST>>& args)
+	{
+		assert(func->template_instance_args);
+		assert(func->template_instance_args->size() == 2);
+		assert(args.size() == 1);
+		auto& targs = *func->template_instance_args;
+		auto v = args[0]->Generate();
+		auto ty = GetLLVMTypeFromResolvedType(targs[0].type);
+		if (targs[1].type.isInteger())
+		{
+			//targs[0] is target type
+			//targs[1] is source type
+			if (targs[0].type.isInteger())
+			{
+				//if both src and dest are integer, generate int cast
+				//extension rule is based on whether src is signed
+				return builder.CreateIntCast(v, ty, targs[1].type.isSigned());
+			}
+			return builder.CreateIntToPtr(v, ty);
+		}
+		return builder.CreatePointerCast(v, ty);
+	}
+
+	static llvm::Value* Intrinsic_UnsafePtrLoad_Generate(FunctionAST* func, llvm::Value* obj, vector<unique_ptr<ExprAST>>& args)
+	{
+		assert(func->template_instance_args);
+		assert(func->template_instance_args->size() == 1);
+		assert(args.size() == 1);
+		auto& targs = *func->template_instance_args;
+		auto v = args[0]->Generate();
+		auto ty = GetLLVMTypeFromResolvedType(targs[0].type);
+		auto ptr = builder.CreatePointerCast(v, ty->getPointerTo());
+		return builder.CreateLoad(ptr);
+	}
+
+	static void Intrinsic_UnsafePtrStore_Phase1(FunctionAST* func)
+	{
+		CheckIntrinsic(func, 2, 1);
+		auto& targs = *func->template_instance_args;
+		CompileAssert(targs[0].kind == TemplateArgument::TEMPLATE_ARG_TYPE,
+			func->Pos, "The 1st template argument for unsafe.ptr_store should be a type");
+		auto& arg_t = func->Proto->resolved_args[0]->resolved_type;
+		CompileAssert(arg_t.type == tok_pointer || arg_t.index_level == 0,
+			func->Pos, "The parameter for unsafe.ptr_store should be a pointer");
+	}
+
+	static llvm::Value* Intrinsic_UnsafePtrStore_Generate(FunctionAST* func, llvm::Value* obj, vector<unique_ptr<ExprAST>>& args)
+	{
+		assert(func->template_instance_args);
+		assert(func->template_instance_args->size() == 1);
+		assert(args.size() == 2);
+		auto& targs = *func->template_instance_args;
+		auto v = args[0]->Generate();
+		auto ty = GetLLVMTypeFromResolvedType(targs[0].type);
+		auto ptr = builder.CreatePointerCast(v, ty->getPointerTo());
+		auto v2 = args[1]->Generate();
+		return builder.CreateStore(v2, ptr);
+	}
+
+	static void Intrinsic_UnsafeBitCast_Phase1(FunctionAST* func)
+	{
+		CheckIntrinsic(func, 1, 2);
+		auto& targs = *func->template_instance_args;
+		CompileAssert(targs[0].kind == TemplateArgument::TEMPLATE_ARG_TYPE && targs[1].kind == TemplateArgument::TEMPLATE_ARG_TYPE,
+			func->Pos, "The 1st and 2nd template arguments for unsafe.bit_cast should be a type");
+	}
+
+	static llvm::Value* Intrinsic_UnsafeBitCast_Generate(FunctionAST* func, llvm::Value* obj, vector<unique_ptr<ExprAST>>& args)
+	{
+		assert(func->template_instance_args);
+		assert(func->template_instance_args->size() == 2);
+		assert(args.size() == 1);
+		auto& targs = *func->template_instance_args;
+		auto v = args[0]->Generate();
+		auto ty = GetLLVMTypeFromResolvedType(targs[0].type);
+		auto srcty = GetLLVMTypeFromResolvedType(targs[1].type);
+		CompileAssert(GetLLVMTypeSizeInBit(ty) == GetLLVMTypeSizeInBit(srcty), func->Pos, 
+			string("Cannot bitcast from type ") + targs[1].type.GetString() + " to type " + targs[0].type.GetString() + ", because they have different sizes");
+		return builder.CreateBitOrPointerCast(v, ty);
+	}
+
+	static IntrisicFunction unsafe_bit_cast = { Intrinsic_UnsafeBitCast_Generate , Intrinsic_UnsafeBitCast_Phase1 };
+	static IntrisicFunction unsafe_ptr_cast = { Intrinsic_UnsafePtrCast_Generate , Intrinsic_UnsafePtrCast_Phase1 };
+	static IntrisicFunction unsafe_ptr_load = { Intrinsic_UnsafePtrLoad_Generate , Intrinsic_UnsafePtrLoad_Phase1 };
+	static IntrisicFunction unsafe_ptr_store = { Intrinsic_UnsafePtrStore_Generate , Intrinsic_UnsafePtrStore_Phase1 };
+
+	static unordered_map<string, unordered_map<string, IntrisicFunction*>> intrinsic_module_names = {
+		{"unsafe",{
+			{"ptr_cast",&unsafe_ptr_cast},
+			{"ptr_load",&unsafe_ptr_load},
+			{"ptr_store",&unsafe_ptr_store},
+			{"bit_cast",&unsafe_bit_cast},
+			}
+		},
+	};
+	bool IsIntrinsicModule(const string& name)
+	{
+		return intrinsic_module_names.find(name) != intrinsic_module_names.end();
+	}
+
+	IntrisicFunction* FindIntrinsic(FunctionAST* func)
+	{
+		bool _is_intrinsic;
+		unordered_map<string, unordered_map<string, IntrisicFunction*>>::iterator itr1;
+		if (func->Proto->prefix_idx == -1)
+		{
+			_is_intrinsic = cu.is_intrinsic;
+			//in most cases, modules are not intrinsic. We can save a map finding here.
+			if (_is_intrinsic)
+				itr1 = intrinsic_module_names.find(cu.symbol_prefix.substr(0, cu.symbol_prefix.length() - 1)); //symbol_prefix has a "." at the end
+		}
+		else
+		{
+			itr1 = intrinsic_module_names.find(cu.imported_module_names[func->Proto->prefix_idx]);
+			_is_intrinsic = itr1 != intrinsic_module_names.end();
+		}
+		if (_is_intrinsic)
+		{
+			unordered_map<string, IntrisicFunction*>::iterator itr2;
+			auto fpos = func->Proto->Name.find('[');
+			if (fpos != string::npos)
+				itr2 = itr1->second.find(func->Proto->Name.substr(0, fpos));
+			else
+				itr2 = itr1->second.find(func->Proto->Name);
+			if (itr2 != itr1->second.end())
+			{
+				return itr2->second;
+			}
+		}
+		return nullptr;
+	}
+}

--- a/Birdee/Makefile
+++ b/Birdee/Makefile
@@ -12,7 +12,7 @@ $(BIN_DIR)/birdeec: Birdee.o $(LIB_DIR)/libBirdeeCompilerCore.so $(LIB_DIR)/libB
 $(LIB_DIR)/libBirdeeBinding.so: PythonBinding.o PythonBinding2.o $(LIB_DIR)/libBirdeeCompilerCore.so 
 	$(CXX) -shared -o $@ $(CPPFLAGS) -L$(LIB_DIR) -Wl,--start-group PythonBinding.o PythonBinding2.o $(LIBS) $(PYLIBS) -lBirdeeCompilerCore -Wl,--end-group  -Wl,-rpath='$$ORIGIN'
 
-$(LIB_DIR)/libBirdeeCompilerCore.so: CodeGen.o NumberCast.o Preprocessing.o Parser.o MetadataSerializer.o MetadataDeserializer.o CopyAST.o BirdeeShared.o
+$(LIB_DIR)/libBirdeeCompilerCore.so: CodeGen.o NumberCast.o Preprocessing.o Parser.o MetadataSerializer.o MetadataDeserializer.o CopyAST.o BirdeeShared.o Intrinsics.o
 	$(CXX) -shared -o $@ $(CPPFLAGS) -Wl,--start-group $^ -lLLVM-6.0 $(LIBS) -Wl,--end-group -Wl,-rpath='$$ORIGIN'
 
 override CPPFLAGS := -fPIC -fvisibility=hidden -flto=thin $(CPPFLAGS)

--- a/Birdee/NumberCast.cpp
+++ b/Birdee/NumberCast.cpp
@@ -75,19 +75,19 @@ GenerateCastSame(tok_double, tok_double);
 
 GenerateCastFP2I(tok_int, tok_long, CreateSExtOrTrunc, getInt64Ty);
 GenerateCastFP2I(tok_int, tok_byte, CreateSExtOrTrunc, getInt8Ty);
-GenerateCastFP2I(tok_int, tok_ulong, CreateZExtOrTrunc, getInt64Ty);
+GenerateCastFP2I(tok_int, tok_ulong, CreateSExtOrTrunc, getInt64Ty);
 GenerateCastFP2I(tok_uint, tok_long, CreateZExtOrTrunc, getInt64Ty);
 GenerateCastFP2I(tok_uint, tok_byte, CreateZExtOrTrunc, getInt8Ty);
 GenerateCastFP2I(tok_uint, tok_ulong, CreateZExtOrTrunc, getInt64Ty);
-GenerateCastFP2I(tok_byte, tok_long, CreateZExtOrTrunc, getInt64Ty);
-GenerateCastFP2I(tok_byte, tok_ulong, CreateZExtOrTrunc, getInt64Ty);
+GenerateCastFP2I(tok_byte, tok_long, CreateSExtOrTrunc, getInt64Ty);
+GenerateCastFP2I(tok_byte, tok_ulong, CreateSExtOrTrunc, getInt64Ty);
 GenerateCastFP2I(tok_long, tok_byte, CreateSExtOrTrunc, getInt8Ty);
-GenerateCastFP2I(tok_ulong, tok_byte, CreateSExtOrTrunc, getInt8Ty);
+GenerateCastFP2I(tok_ulong, tok_byte, CreateZExtOrTrunc, getInt8Ty);
 
 GenerateCastFP2I(tok_byte, tok_int, CreateSExtOrTrunc, getInt32Ty);
-GenerateCastFP2I(tok_byte, tok_uint, CreateZExtOrTrunc, getInt32Ty);
+GenerateCastFP2I(tok_byte, tok_uint, CreateSExtOrTrunc, getInt32Ty);
 GenerateCastFP2I(tok_long, tok_int, CreateSExtOrTrunc, getInt32Ty);
-GenerateCastFP2I(tok_long, tok_uint, CreateZExtOrTrunc, getInt32Ty);
-GenerateCastFP2I(tok_ulong, tok_int, CreateSExtOrTrunc, getInt32Ty);
+GenerateCastFP2I(tok_long, tok_uint, CreateSExtOrTrunc, getInt32Ty);
+GenerateCastFP2I(tok_ulong, tok_int, CreateZExtOrTrunc, getInt32Ty);
 GenerateCastFP2I(tok_ulong, tok_uint, CreateZExtOrTrunc, getInt32Ty);
 

--- a/Birdee/Parser.cpp
+++ b/Birdee/Parser.cpp
@@ -1339,6 +1339,11 @@ vector<string> ParsePackageName()
 	return ret;;
 }
 
+namespace Birdee
+{
+	extern bool IsIntrinsicModule(const string& name);
+}
+
 void ParsePackage()
 {
 	if (tokenizer.CurTok == tok_package)
@@ -1363,6 +1368,7 @@ void ParsePackage()
 	{
 		cu.symbol_prefix += cu.filename.substr(0, found);
 	}
+	cu.is_intrinsic = IsIntrinsicModule(cu.symbol_prefix);
 	cu.symbol_prefix += '.';
 
 }

--- a/Birdee/PythonBinding.cpp
+++ b/Birdee/PythonBinding.cpp
@@ -269,7 +269,10 @@ void RegisiterClassForBinding2(py::module& m) {
 			[](IndexExprAST& ths, UniquePtrStatementAST& v) {ths.Index = v.move_expr(); })
 		.def_property("template_inst", [](IndexExprAST& ths) {return GetRef(ths.instance); },
 			[](IndexExprAST& ths, UniquePtrStatementAST& v) {ths.instance = move_cast_or_throw< FunctionTemplateInstanceExprAST>(v.ptr); })
-		.def("is_template_instance",&IndexExprAST::isTemplateInstance)
+		.def("is_template_instance", [](IndexExprAST& ths) {
+			unique_ptr<ExprAST>* dumy;
+			return ths.isTemplateInstance(dumy);
+		})
 		.def("run", [](IndexExprAST& ths, py::object& func) {
 			if (ths.Expr)
 				func(GetRef(ths.Expr));

--- a/Birdee/PythonBinding2.cpp
+++ b/Birdee/PythonBinding2.cpp
@@ -14,6 +14,7 @@ extern Birdee::Tokenizer SwitchTokenizer(Birdee::Tokenizer&& tokzr);
 extern std::unique_ptr<ExprAST> ParseExpressionUnknown();
 extern int ParseTopLevel();
 extern std::reference_wrapper<FunctionAST> GetCurrentPreprocessedFunction();
+BD_CORE_API std::reference_wrapper<ClassAST> GetCurrentPreprocessedClass();
 extern std::unique_ptr<Type> ParseTypeName();
 extern unique_ptr<StatementAST> ParseStatement();
 
@@ -297,6 +298,8 @@ BIRDEE_BINDING_API void Birdee_RunAnnotationsOn(std::vector<std::string>& anno,S
 BD_CORE_API bool ParseClassBody(ClassAST* cls);
 BD_CORE_API void PushClass(ClassAST* cls);
 BD_CORE_API void PopClass();
+BD_CORE_API int GetTypeSize(ResolvedType ty);
+
 static void CompileClassBody(ClassAST* cls, const char* src)
 {
 	PushClass(cls);
@@ -366,8 +369,21 @@ void RegisiterClassForBinding(py::module& m)
 		m.def("set_print_ir", [](bool printir) {cu.is_print_ir = printir; });
 		cu.InitForGenerate();
 	}
+	m.def("get_os_name", []()->std::string {
+#ifdef _WIN32
+		return "windows";
+#elif defined(__linux__)
+		return "linux";
+#else
+		#error "unknown target name"
+#endif
+	});
+	m.def("get_target_bits", []()->int {
+		return 64;
+	});
 	m.def("class_body", CompileClassBody);
 	m.def("resolve_type", ResolveType);
+	m.def("size_of", GetTypeSize);
 	py::class_ < CompileError>(m, "CompileError")
 		.def_property_readonly("linenumber", [](CompileError& ths) {return ths.pos.line; })
 		.def_property_readonly("pos", [](CompileError& ths) {return ths.pos.pos; })
@@ -396,6 +412,7 @@ void RegisiterClassForBinding(py::module& m)
 	m.def("set_ast", [](UniquePtrStatementAST& ptr) {outexpr = ptr.move(); });
 	m.def("set_type", [](ResolvedType& ty) {outtype = ty; });
 	m.def("get_cur_func", GetCurrentPreprocessedFunction);
+	m.def("get_cur_class", GetCurrentPreprocessedClass);
 	m.def("get_func", [](const std::string& name) {
 		auto itr = cu.funcmap.find(name);
 		if (itr == cu.funcmap.end())

--- a/Birdee/include/BdAST.h
+++ b/Birdee/include/BdAST.h
@@ -665,7 +665,8 @@ namespace Birdee {
 		//resolve expr, and check if expr is a class object
 		bool isOverloaded();
 		std::unique_ptr<StatementAST> Copy();
-		bool isTemplateInstance();
+		//if expr is identifier with implied this, will set "member" parameter
+		bool isTemplateInstance(unique_ptr<ExprAST>*& member);
 		llvm::Value* Generate();
 		llvm::Value* GetLValue(bool checkHas) override;
 		IndexExprAST(std::unique_ptr<ExprAST>&& Expr,
@@ -1224,19 +1225,7 @@ namespace Birdee {
 		void PreGenerateFuncs();
 
 		//run phase0 in all members
-		void Phase0()
-		{
-			if (isTemplate())
-				return;
-			for (auto& funcdef : funcs)
-			{
-				funcdef.decl->Phase0();
-			}
-			for (auto& fielddef : fields)
-			{
-				fielddef.decl->Phase0();
-			}
-		}
+		void Phase0();
 		void Phase1();
 
 		void print(int level)

--- a/BirdeeCompilerCore/BirdeeCompilerCore.vcxproj
+++ b/BirdeeCompilerCore/BirdeeCompilerCore.vcxproj
@@ -155,6 +155,7 @@
     <ClCompile Include="..\Birdee\BirdeeShared.cpp" />
     <ClCompile Include="..\Birdee\CodeGen.cpp" />
     <ClCompile Include="..\Birdee\CopyAST.cpp" />
+    <ClCompile Include="..\Birdee\Intrinsics.cpp" />
     <ClCompile Include="..\Birdee\MetadataDeserializer.cpp" />
     <ClCompile Include="..\Birdee\MetadataSerializer.cpp" />
     <ClCompile Include="..\Birdee\NumberCast.cpp" />

--- a/BirdeeCompilerCore/BirdeeCompilerCore.vcxproj.filters
+++ b/BirdeeCompilerCore/BirdeeCompilerCore.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClCompile Include="..\Birdee\BirdeeShared.cpp">
       <Filter>源文件</Filter>
     </ClCompile>
+    <ClCompile Include="..\Birdee\Intrinsics.cpp">
+      <Filter>源文件</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Birdee\include\abort.h">

--- a/BirdeeHome/src/Makefile
+++ b/BirdeeHome/src/Makefile
@@ -6,7 +6,7 @@ BLIB_DIR=$(PARENT_DIR)/blib
 BIN=$(PARENT_DIR)/bin
 LIB=$(PARENT_DIR)/lib
 
-all: ${BLIB_DIR}/birdee.o ${BLIB_DIR}/list.o ${BLIB_DIR}/hash_map.o ${BLIB_DIR}/hash_set.o ${LIB} ${BLIB_DIR}/tuple.o ${BLIB_DIR}/fmt.o ${BLIB_DIR}/vector.o ${BLIB_DIR}/queue.o ${BLIB_DIR}/stack.o ${BLIB_DIR}/unsafe.o
+all: ${BLIB_DIR}/birdee.o ${BLIB_DIR}/variant.o ${BLIB_DIR}/list.o ${BLIB_DIR}/hash_map.o ${BLIB_DIR}/hash_set.o ${LIB} ${BLIB_DIR}/tuple.o ${BLIB_DIR}/fmt.o ${BLIB_DIR}/vector.o ${BLIB_DIR}/queue.o ${BLIB_DIR}/stack.o ${BLIB_DIR}/unsafe.o
 
 print-%  : ; @echo $* = $($*)
 
@@ -50,6 +50,9 @@ ${BLIB_DIR}/stack.o: stack.txt ${BLIB_DIR}/birdee.o
 
 ${BLIB_DIR}/unsafe.o: unsafe.txt ${BLIB_DIR}/birdee.o
 	$(BIN)/birdeec -i unsafe.txt -o $(BLIB_DIR)/unsafe.o
+
+${BLIB_DIR}/variant.o: variant.txt ${BLIB_DIR}/birdee.o
+	$(BIN)/birdeec -i variant.txt -o $(BLIB_DIR)/variant.o
 
 clean:
 	rm -rf ${BLIB_DIR}

--- a/BirdeeHome/src/Makefile
+++ b/BirdeeHome/src/Makefile
@@ -6,7 +6,7 @@ BLIB_DIR=$(PARENT_DIR)/blib
 BIN=$(PARENT_DIR)/bin
 LIB=$(PARENT_DIR)/lib
 
-all: ${BLIB_DIR}/birdee.o ${BLIB_DIR}/list.o ${BLIB_DIR}/hash_map.o ${BLIB_DIR}/hash_set.o ${LIB} ${BLIB_DIR}/tuple.o ${BLIB_DIR}/fmt.o ${BLIB_DIR}/vector.o ${BLIB_DIR}/queue.o ${BLIB_DIR}/stack.o
+all: ${BLIB_DIR}/birdee.o ${BLIB_DIR}/list.o ${BLIB_DIR}/hash_map.o ${BLIB_DIR}/hash_set.o ${LIB} ${BLIB_DIR}/tuple.o ${BLIB_DIR}/fmt.o ${BLIB_DIR}/vector.o ${BLIB_DIR}/queue.o ${BLIB_DIR}/stack.o ${BLIB_DIR}/unsafe.o
 
 print-%  : ; @echo $* = $($*)
 
@@ -47,6 +47,9 @@ ${BLIB_DIR}/queue.o: queue.txt ${BLIB_DIR}/birdee.o
 
 ${BLIB_DIR}/stack.o: stack.txt ${BLIB_DIR}/birdee.o
 	$(BIN)/birdeec -i stack.txt -o $(BLIB_DIR)/stack.o
+
+${BLIB_DIR}/unsafe.o: unsafe.txt ${BLIB_DIR}/birdee.o
+	$(BIN)/birdeec -i unsafe.txt -o $(BLIB_DIR)/unsafe.o
 
 clean:
 	rm -rf ${BLIB_DIR}

--- a/BirdeeHome/src/unsafe.txt
+++ b/BirdeeHome/src/unsafe.txt
@@ -1,0 +1,11 @@
+function ptr_cast[T1,T2](a as T2) as T1
+end
+
+function ptr_load[T1](a as pointer) as T1
+end
+
+function ptr_store[T1](a as pointer, v as T1)
+end
+
+function bit_cast[T1,T2](a as T2) as T1
+end

--- a/BirdeeHome/src/variant.txt
+++ b/BirdeeHome/src/variant.txt
@@ -1,0 +1,53 @@
+import unsafe
+
+@enable_rtti
+class bad_variant_access
+
+end
+
+@init_script
+{@
+def get_variant_idx():
+	func = get_cur_func()
+	target_type = func.template_instance_args[0].resolved_type
+	idx=0
+	cls=get_cur_class()
+	for arg in cls.template_instance_args:
+		if target_type == arg.resolved_type:
+			return idx
+		idx+=1
+	raise RuntimeError("The type "+ str(target_type) + " is not defined in the variant")
+@}
+
+struct variant[...]
+	private index as int
+	private data as {@
+cls=get_cur_class()
+rty=0
+max_sz=0
+if len(cls.template_instance_args)==0:
+	raise RuntimeError("Variants must have more than 0 template arguments")
+for arg in cls.template_instance_args:
+	cur_sz=size_of(arg.resolved_type)
+	if cur_sz>max_sz:
+		max_sz=cur_sz
+		rty=arg.resolved_type
+set_type(rty)
+@}
+	
+	public function is_type[T]() as boolean
+		return index == {@set_ast(NumberExprAST.new(BasicType.INT,get_variant_idx()))@}
+	end
+	public function set[T](a as T)
+		index = {@set_ast(NumberExprAST.new(BasicType.INT,get_variant_idx()))@}
+		dim ptr = addressof(data)
+		unsafe.ptr_store(ptr,a)
+	end
+	public function get[T]() as T
+		if is_type[T]()!=true then
+			throw new bad_variant_access
+		end
+		dim ptr = addressof(data)
+		return unsafe.ptr_load[T](ptr)
+	end
+end

--- a/CoreLibs/makefile2.mak
+++ b/CoreLibs/makefile2.mak
@@ -1,4 +1,4 @@
-all: birdee list hash_map hash_set vector queue stack tuple fmt unsafe
+all: birdee list hash_map hash_set vector queue stack tuple fmt unsafe variant
 BLIB_DIR=$(BIRDEE_HOME)\blib
 
 $(BLIB_DIR):
@@ -32,6 +32,9 @@ fmt: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\fmt.txt
 
 unsafe: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\unsafe.txt
 	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\unsafe.txt -o $(BIRDEE_HOME)\blib\unsafe.obj
+
+variant: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\variant.txt
+	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\variant.txt -o $(BIRDEE_HOME)\blib\variant.obj
 
 clean:
 	del $(BLIB_DIR)\*.obj

--- a/CoreLibs/makefile2.mak
+++ b/CoreLibs/makefile2.mak
@@ -1,4 +1,4 @@
-all: birdee list hash_map hash_set vector queue stack tuple fmt
+all: birdee list hash_map hash_set vector queue stack tuple fmt unsafe
 BLIB_DIR=$(BIRDEE_HOME)\blib
 
 $(BLIB_DIR):
@@ -29,6 +29,9 @@ tuple: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\tuple.txt
 
 fmt: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\fmt.txt
 	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\fmt.txt -o $(BIRDEE_HOME)\blib\fmt.obj
+
+unsafe: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\unsafe.txt
+	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\unsafe.txt -o $(BIRDEE_HOME)\blib\unsafe.obj
 
 clean:
 	del $(BLIB_DIR)\*.obj

--- a/tests/scripttest.py
+++ b/tests/scripttest.py
@@ -18,6 +18,59 @@ def assert_ok(istr):
 	process_top_level()
 	clear_compile_unit()
 
+def assert_generate_ok(istr):
+	top_level(istr)
+	process_top_level()
+	generate()
+	clear_compile_unit()
+
+def assert_generate_fail(istr):
+	try:
+		top_level(istr)
+		process_top_level()
+		generate()
+		assert(False)
+	except TokenizerException:
+		e=get_tokenizer_error()
+		print(e.linenumber,e.pos,e.msg)
+	except CompileException:
+		e=get_compile_error()
+		print(e.linenumber,e.pos,e.msg)		
+	clear_compile_unit()
+
+set_print_ir(False)
+
+assert_generate_ok('''
+import unsafe:*
+dim a as pointer
+dim b as string = ptr_cast[string](a)
+dim c as int[] = ptr_cast[int[]](b)
+dim d as ulong = ptr_cast[ulong](c)
+dim e as uint = d
+c = ptr_cast[int[]](e)
+a = ptr_cast[pointer](c)
+d = ptr_cast[ulong](e)
+
+d = ptr_load[ulong](a)
+b = ptr_load[string](a)
+
+ptr_store(a,d)
+ptr_store(a,b)
+
+b = bit_cast[string](a)
+b = bit_cast[string](d)
+
+dim k = ptr_load[ulong]
+'''
+)
+
+assert_generate_fail('''
+import unsafe:*
+dim b as string
+dim e as uint
+b = bit_cast[string](e)
+''')
+
 assert_ok('''
 class a[T]
 end

--- a/tests/scripttest.py
+++ b/tests/scripttest.py
@@ -40,6 +40,23 @@ def assert_generate_fail(istr):
 
 set_print_ir(False)
 
+print("The OS name is ", get_os_name(), ". The target bit width is ", get_target_bits())
+
+assert_ok('''
+import variant:variant
+dim v as variant[byte,int,long,string]
+v.set(1)
+v.set(2L)
+v.set("1234")
+println(v.get[string]())
+''')
+
+assert_ok('''
+{@assert(size_of(resolve_type("string"))==get_target_bits()/8)@}
+{@assert(size_of(resolve_type("long"))==8)@}
+''')
+
+
 assert_generate_ok('''
 import unsafe:*
 dim a as pointer


### PR DESCRIPTION
We can now define intrinsic functions. They are implemented by birdee compiler and will be lowered down to LLVM instructions instead of function calls.
I have currently implemented bit_cast,ptr_cast,ptr_load,ptr_store.

bit_cast converts a value to another type by bit-by-bit copying. The src type and dest type must have the same size. Example: 
```
unsafe.bit_cast[ulong]("123")
```
ptr_cast converts reference/pointer/integers among each other. E.g.
```
unsafe.ptr_cast[int[]]("123")
```
ptr_load and ptr_store reads/writes a value referenced by a pointer
```
dim a as int
dim b as poiner = addressof(a)
unsafe.ptr_store(b,1234) #same as a=1234
dim c as int = unsafe.ptr_load[int](b) # same as c=a 
```
