### PR TITLE
Script enhancement

### DIFF
--- a/Birdee/Birdee.vcxproj
+++ b/Birdee/Birdee.vcxproj
@@ -192,6 +192,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <Text Include="..\BirdeeHome\pylib\bdutils.py" />
     <Text Include="..\BirdeeHome\src\functional.txt" />
     <Text Include="..\BirdeeHome\src\unsafe.txt" />
     <Text Include="..\BirdeeHome\src\variant.txt" />

--- a/Birdee/Birdee.vcxproj
+++ b/Birdee/Birdee.vcxproj
@@ -208,6 +208,7 @@
     <Text Include="..\BirdeeHome\src\template_test.txt" />
     <Text Include="..\BirdeeHome\src\tuple.txt" />
     <Text Include="..\tests\exception_test.txt" />
+    <Text Include="..\tests\hardware_exception_test.txt" />
     <Text Include="..\tests\hash_map_test.txt" />
     <Text Include="..\tests\logic_obj_cmp.txt" />
     <Text Include="..\tests\operators.txt" />

--- a/Birdee/Birdee.vcxproj.filters
+++ b/Birdee/Birdee.vcxproj.filters
@@ -91,9 +91,6 @@
     <Text Include="llvm.txt">
       <Filter>资源文件</Filter>
     </Text>
-    <Text Include="..\BirdeeHome\src\birdee.txt">
-      <Filter>资源文件</Filter>
-    </Text>
     <Text Include="..\BirdeeHome\src\test.txt">
       <Filter>资源文件</Filter>
     </Text>
@@ -149,6 +146,12 @@
       <Filter>资源文件\blib</Filter>
     </Text>
     <Text Include="..\BirdeeHome\src\variant.txt">
+      <Filter>资源文件\blib</Filter>
+    </Text>
+    <Text Include="..\tests\hardware_exception_test.txt">
+      <Filter>资源文件\tests</Filter>
+    </Text>
+    <Text Include="..\BirdeeHome\src\birdee.txt">
       <Filter>资源文件\blib</Filter>
     </Text>
   </ItemGroup>

--- a/Birdee/Birdee.vcxproj.filters
+++ b/Birdee/Birdee.vcxproj.filters
@@ -154,6 +154,9 @@
     <Text Include="..\BirdeeHome\src\birdee.txt">
       <Filter>资源文件\blib</Filter>
     </Text>
+    <Text Include="..\BirdeeHome\pylib\bdutils.py">
+      <Filter>资源文件\pylib</Filter>
+    </Text>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\tests\ast_write_test.py">

--- a/Birdee/BirdeeShared.cpp
+++ b/Birdee/BirdeeShared.cpp
@@ -484,6 +484,13 @@ Token Birdee::Tokenizer::gettok() {
 		Token ret = gettok();
 		if (ret != tok_identifier)
 			throw TokenizerError(line, pos, "Expected an identifier after \'@\'");
+		if (!isspace(LastChar) && LastChar != '\n') //if annotation is not followed by a " ", parse until the end of the line
+		{
+			do {
+				IdentifierStr += LastChar;
+				LastChar = GetChar();
+			} while (LastChar != EOF && LastChar != '\n' && LastChar != '\r');
+		}
 		return tok_annotation;
 	}
 	// Check for end of file.  Don't eat the EOF.

--- a/Birdee/MetadataDeserializer.cpp
+++ b/Birdee/MetadataDeserializer.cpp
@@ -666,6 +666,8 @@ void ImportedModule::Init(const vector<string>& package, const string& module_na
 	BuildClassFromJson(json["Classes"], *this);
 	BuildOrphanClassFromJson(json["ImportedClasses"], *this);
 
+	if (package.size() == 1 && package[0] == "birdee") //if is "birdee" core package, generate "type_info" first
+		classmap.find("type_info")->second->PreGenerate();
 	for (auto& cls : this->classmap)
 	{
 		cls.second->PreGenerate();//it is safe to call multiple times

--- a/Birdee/Parser.cpp
+++ b/Birdee/Parser.cpp
@@ -485,6 +485,7 @@ unique_ptr<ExprAST> ParseIndexOrTemplateInstance(unique_ptr<ExprAST> expr,Source
 			auto type = make_unique<QualifiedIdentifierType>(ex->ToStringArray());
 			auto nexpr = make_unique<BasicTypeExprAST>();
 			nexpr->type = std::move(type);
+			nexpr->type->index_level = 1;
 			expr = std::move(nexpr);
 		},
 			[](FunctionTemplateInstanceExprAST* ex) {
@@ -498,6 +499,13 @@ unique_ptr<ExprAST> ParseIndexOrTemplateInstance(unique_ptr<ExprAST> expr,Source
 		},
 			[](StringLiteralAST* ex) {
 			throw CompileError("Cannot apply index on string");
+		},
+			[&expr](ScriptAST* ex) {
+			auto type = make_unique<ScriptType>(ex->script);
+			auto nexpr = make_unique<BasicTypeExprAST>();
+			nexpr->type = std::move(type);
+			nexpr->type->index_level = 1;
+			expr = std::move(nexpr);
 		},
 			[]() {
 			throw CompileError("Invalid template argument expression type for []");

--- a/Birdee/Preprocessing.cpp
+++ b/Birdee/Preprocessing.cpp
@@ -1846,19 +1846,6 @@ If usage vararg name is "", match the closest vararg
 		return ret;
 	}
 
-
-
-	// void AddressOfExprAST::Phase1()
-	// {
-	// 	
-	// 	expr->Phase1();
-	// 	if (is_address_of)
-	// 		CompileAssert(expr->GetLValue(true), Pos, "The expression in addressof should be a LValue");			
-	// 	else
-	// 		CompileAssert(expr->resolved_type.isReference(), Pos, "The expression in pointerof should be a reference type");
-	// 	resolved_type.type = tok_pointer;
-	// }
-
 	bool IndexExprAST::isOverloaded()
 	{
 		if (!Expr->resolved_type.isResolved())

--- a/Birdee/Preprocessing.cpp
+++ b/Birdee/Preprocessing.cpp
@@ -2123,7 +2123,9 @@ If usage vararg name is "", match the closest vararg
 		if (cu.is_corelib)
 			return &(cu.classmap.find(name)->second.get());
 		else
-			return cu.imported_classmap.find(name)->second;
+		{
+			return cu.imported_packages.FindName("birdee")->mod->classmap.find(name)->second.get();
+		}
 	}
 
 	void TypeofExprAST::Phase1()

--- a/Birdee/PythonBinding2.cpp
+++ b/Birdee/PythonBinding2.cpp
@@ -142,8 +142,6 @@ BIRDEE_BINDING_API void Birdee_ScriptAST_Phase1(ScriptAST* ths, void* globals, v
 		throw CompileError(ths->Pos, string("\nScript exception:\n") + e.what());
 	}
 	ths->stmt = std::move(outexpr);
-	outexpr = nullptr;
-	outtype.type = tok_error;
 	if (ths->stmt)
 	{
 		ths->stmt->Phase1();
@@ -152,6 +150,12 @@ BIRDEE_BINDING_API void Birdee_ScriptAST_Phase1(ScriptAST* ths, void* globals, v
 		else
 			ths->resolved_type.type = tok_error;
 	}
+	else
+	{
+		ths->type_data = outtype;
+	}
+	outexpr = nullptr;
+	outtype = ResolvedType();
 }
 
 static UniquePtrStatementAST CompileExpr(char* cmd) {

--- a/Birdee/PythonBinding2.cpp
+++ b/Birdee/PythonBinding2.cpp
@@ -286,8 +286,7 @@ BIRDEE_BINDING_API void Birdee_RunAnnotationsOn(std::vector<std::string>& anno,S
 	{
 		for (auto& func_name : anno)
 		{
-			auto pfunc = PyDict_GetItemString(g_dict.ptr(), func_name.c_str());
-			auto func = py::cast<py::object>(pfunc);
+			auto func = py::eval(func_name, g_dict);
 			if (!func)
 				throw CompileError(pos, string("\nCannot find function for annotation: ") + func_name);
 			func(GetRef(impl));

--- a/Birdee/include/BdAST.h
+++ b/Birdee/include/BdAST.h
@@ -1349,6 +1349,11 @@ namespace Birdee {
 	class BD_CORE_API ScriptAST : public ExprAST
 	{
 	public:
+		//ScriptAST can be contained in template argument in a BasicTypeExpr. So it can serve as an expression, or can be served
+		//as a resolved type. The field type_data is only valid when stmt is empty (when the user only calls set_type but never calls set_ast() ).
+		//But if stmt is empty, type_data can be invalid in some cases - user did not call either set_ast() or set_type()
+		ResolvedType type_data;
+		//In most cases, ScriptAST is used as a general expr.
 		unique_ptr<StatementAST> stmt;
 		string script;
 		virtual Value* Generate();

--- a/Birdee/include/TemplateUtil.h
+++ b/Birdee/include/TemplateUtil.h
@@ -5,9 +5,9 @@
 namespace Birdee
 {
 	template <typename T1, typename T2, typename T3, typename T4,
-		typename T5, typename T6, typename T7, typename T8>
+		typename T5, typename T6, typename T7, typename T8, typename T9>
 	void RunOnTemplateArg(ExprAST* ptr, T1 on_basic_type, T2 on_identifier, T3 on_member,
-		T4 on_template_ins, T5 on_index, T6 on_number, T7 on_str,T8 on_other)
+		T4 on_template_ins, T5 on_index, T6 on_number, T7 on_str, T8 on_script, T9 on_other)
 	{
 #define CALL(NAME,FUNC) 	if (instance_of<NAME>(ptr)) \
 		{\
@@ -22,6 +22,7 @@ namespace Birdee
 		CALL(IndexExprAST, on_index);
 		CALL(NumberExprAST, on_number);
 		CALL(StringLiteralAST, on_str);
+		CALL(ScriptAST, on_script);
 		on_other();
 #undef CALL
 	}

--- a/BirdeeHome/pylib/bdutils.py
+++ b/BirdeeHome/pylib/bdutils.py
@@ -1,0 +1,66 @@
+from birdeec import *
+from traits import *
+
+#utilities for making AST/type
+def make_int(n):
+	return NumberExprAST.new(BasicType.INT,n)
+def set_int(n):
+	set_ast(make_int(n))
+def make_uint(n):
+	return NumberExprAST.new(BasicType.UINT,n)
+def set_uint(n):
+	set_ast(make_uint(n))
+
+def make_long(n):
+	return NumberExprAST.new(BasicType.LONG,n)
+def set_long(n):
+	set_ast(make_long(n))
+def make_ulong(n):
+	return NumberExprAST.new(BasicType.ULONG,n)
+def set_ulong(n):
+	set_ast(make_ulong(n))
+
+def make_float(n):
+	return NumberExprAST.new(BasicType.FLOAT,n)
+def set_float(n):
+	set_ast(make_float(n))
+def make_double(n):
+	return NumberExprAST.new(BasicType.DOUBLE,n)
+def set_double(n):
+	set_ast(make_double(n))
+
+def make_bool(n):
+	return BoolLiteralExprAST.new(n)
+def set_bool(n):
+	set_ast(make_bool(n))
+
+def make_str(s):
+	return StringLiteralAST.new(s)
+def set_str(s):
+	set_ast(make_str(s))
+
+def resolve_set_type(s):
+	set_type(resolve_type(s))
+
+
+#utilities for templates
+def get_cls_templ_at(idx):
+	thecls = get_cur_class()
+	require_(is_cls_template_inst(thecls), index_within(idx,0,len(thecls.template_instance_args)))
+	return thecls.template_instance_args[idx]
+
+def get_cls_type_templ_at(idx):
+	arg = get_cls_templ_at(idx)
+	require_(is_type_templ_arg(arg,idx))
+	return arg.resolved_type
+
+def get_cls_expr_templ_at(idx):
+	arg = get_cls_templ_at(idx)
+	require_(is_expr_templ_arg(arg,idx))
+	return arg.expr
+
+def cls_templ_type_at(idx):
+	set_type(get_cls_type_templ_at(idx))
+
+def cls_templ_expr_at(idx):
+	set_ast(get_cls_expr_templ_at(idx))

--- a/BirdeeHome/pylib/traits.py
+++ b/BirdeeHome/pylib/traits.py
@@ -5,6 +5,30 @@ def get_boolean_type():
 	a.set_detail(BasicType.BOOLEAN,None)
 	return a
 
+def require_(*checks):
+	for i in checks:
+		if not i[0]:
+			raise RuntimeError(i[1]())
+
+def is_cls_template_inst(scls):
+	return (scls.is_template_instance(), lambda:"The input class {} is expected to be a template instance".format(scls.get_unique_name()) )
+
+def index_within(index, st, ed):
+	return (st <= index <ed, lambda:"The index {index} is expected to be {st}<= index < {ed}".format(index=index, st= st, ed= ed) )
+
+def is_class(node):
+	return (isinstance(node,ClassAST), lambda:"The AST node {} is expected to be a ClassAST".format(str(node)) )
+
+def is_cls_template(scls):
+	return (scls.is_template(), lambda:"The input class {} is expected to be a template".format(scls.get_unique_name()) )
+
+def is_type_templ_arg(arg,idx):
+	return (arg.kind==TemplateArgument.TemplateArgumentType.TEMPLATE_ARG_TYPE , 
+		lambda:"The {}-th template argument is expected to be a type".format(idx))
+
+def is_expr_templ_arg(args,idx):
+	return (args[idx].kind==TemplateArgument.TemplateArgumentType.TEMPLATE_ARG_EXPR , 
+		lambda:"The {}-th template argument is expected to be an expression".format(idx))
 
 '''
 Check if "type" is a prototype. Throw if not.

--- a/BirdeeHome/pylib/traits.py
+++ b/BirdeeHome/pylib/traits.py
@@ -1,5 +1,7 @@
 from birdeec import *
 
+_ = []
+
 def get_boolean_type():
 	a = ResolvedType()
 	a.set_detail(BasicType.BOOLEAN,None)
@@ -9,6 +11,58 @@ def require_(*checks):
 	for i in checks:
 		if not i[0]:
 			raise RuntimeError(i[1]())
+
+def require(*checks):
+	def ret(curcls):
+		for pack in checks:
+			func = pack[0]
+			args = [0] * (len(pack) - 1)
+			for i in range(1,len(pack)):
+				if id(pack[i])==id(_):
+					args[i-1] = curcls
+				else:
+					args[i-1] = pack[i]
+			result = func(*args)
+			if not result[0]:
+				raise RuntimeError(result[1]())
+	return ret 
+
+def	NOT(func, *args):
+	def not_func(*subargs):
+		result, str_func = func(*subargs)
+		def not_str_func():
+			return "Not({})".format(str_func())
+		return (not result, not_str_func)
+	return (not_func,) + args 
+
+def	AND(pack1, pack2):
+	func1 = pack1[0]
+	func2 = pack2[0]
+	split = len(pack1) - 1 # the number of arguments in first function
+	def and_func(*subargs):
+		args1 = subargs[0: split] #args for first func
+		args2 = subargs[split: ]
+		result1, str_func1 = func1(*args1)
+		result2, str_func2 = func2(*args2)
+		def and_str_func():
+			return "And({} , {})".format(str_func1(), str_func2())
+		return (result1 and result2, and_str_func)
+	return (and_func,) + pack1[1:] + pack2[1:]
+
+
+def	OR(pack1, pack2):
+	func1 = pack1[0]
+	func2 = pack2[0]
+	split = len(pack1) - 1 # the number of arguments in first function
+	def or_func(*subargs):
+		args1 = subargs[0: split] #args for first func
+		args2 = subargs[split: ]
+		result1, str_func1 = func1(*args1)
+		result2, str_func2 = func2(*args2)
+		def or_str_func():
+			return "Or({} , {})".format(str_func1(), str_func2())
+		return (result1 or result2, and_str_func)
+	return (or_func,) + pack1[1:] + pack2[1:]	
 
 def is_cls_template_inst(scls):
 	return (scls.is_template_instance(), lambda:"The input class {} is expected to be a template instance".format(scls.get_unique_name()) )
@@ -21,6 +75,12 @@ def is_class(node):
 
 def is_cls_template(scls):
 	return (scls.is_template(), lambda:"The input class {} is expected to be a template".format(scls.get_unique_name()) )
+
+def is_type_templ_arg_in_class(clazz,idx):
+	require_(is_cls_template_inst(clazz), index_within(idx, 0, len(clazz.template_instance_args)))
+	arg = clazz.template_instance_args[idx]
+	return (arg.kind==TemplateArgument.TemplateArgumentType.TEMPLATE_ARG_TYPE , 
+		lambda:"The {}-th template argument of class {} is expected to be a type".format(idx, clazz.get_unique_name()))
 
 def is_type_templ_arg(arg,idx):
 	return (arg.kind==TemplateArgument.TemplateArgumentType.TEMPLATE_ARG_TYPE , 

--- a/BirdeeHome/src/Makefile
+++ b/BirdeeHome/src/Makefile
@@ -51,7 +51,7 @@ ${BLIB_DIR}/stack.o: stack.txt ${BLIB_DIR}/birdee.o
 ${BLIB_DIR}/unsafe.o: unsafe.txt ${BLIB_DIR}/birdee.o
 	$(BIN)/birdeec -i unsafe.txt -o $(BLIB_DIR)/unsafe.o
 
-${BLIB_DIR}/variant.o: variant.txt ${BLIB_DIR}/birdee.o
+${BLIB_DIR}/variant.o: variant.txt ${BLIB_DIR}/birdee.o ${BLIB_DIR}/unsafe.o
 	$(BIN)/birdeec -i variant.txt -o $(BLIB_DIR)/variant.o
 
 clean:

--- a/BirdeeHome/src/birdee.txt
+++ b/BirdeeHome/src/birdee.txt
@@ -103,3 +103,22 @@ end
 function println(str as string)
 	puts(str.getRaw())
 end
+
+
+@enable_rtti
+class mem_access_exception
+
+end
+
+@enable_rtti
+class div_zero_exception
+
+end
+
+function __create_basic_exception_no_call(ty as int) as pointer
+	if ty==0 then
+		return pointerof(new mem_access_exception)
+	else if ty==1 then
+		return pointerof(new div_zero_exception)
+	end
+end

--- a/BirdeeRuntime/BirdeeRuntime.vcxproj
+++ b/BirdeeRuntime/BirdeeRuntime.vcxproj
@@ -92,6 +92,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/tests/hardware_exception_test.txt
+++ b/tests/hardware_exception_test.txt
@@ -1,0 +1,44 @@
+func test()
+	dim a as string=null
+	println(a)
+end
+
+
+func wrapper1()
+	try
+		test()
+	catch e as mem_access_exception
+		println("Caught SEGV")
+	end
+end
+
+#declare function getchar() as int
+#getchar()
+wrapper1()
+wrapper1()
+wrapper1()
+
+func test2[T]() as T
+	dim a as T = 0
+	return 2/a
+end
+
+
+func wrapper2[T,STR as string]()
+	try
+		test2[T]()
+	catch e as div_zero_exception
+		println(STR)
+	end
+end
+
+wrapper2[int,"int"]()
+wrapper2[int,"int"]()
+wrapper2[int,"int"]()
+
+println("Test done")
+
+#on x86, the following code will not generate exceptions
+wrapper2[double,"double"]()
+wrapper2[double,"double"]()
+wrapper2[double,"double"]()

--- a/tests/scripttest.py
+++ b/tests/scripttest.py
@@ -43,6 +43,30 @@ set_print_ir(False)
 print("The OS name is ", get_os_name(), ". The target bit width is ", get_target_bits())
 
 assert_ok('''
+{@from bdutils import *
+from traits import *
+from traits import _
+def print_ast(node):
+	print(node)
+@}
+dim a = {@set_int(234)@}
+dim b = {@set_str("hello")@}
+dim c as {@resolve_set_type("int")@}
+
+@require((is_cls_template_inst, _), (is_type_templ_arg_in_class, _, 0))
+struct p[...]
+	public v1 as {@cls_templ_type_at(0)@}
+	public v2 as {@cls_templ_type_at(1)@}
+end
+
+dim pv as p[int,string]
+
+@print_ast pv.v1=1
+@print_ast
+pv.v2="str"
+''')
+
+assert_ok('''
 {@from bdutils import *@}
 dim a = {@set_int(234)@}
 dim b = {@set_str("hello")@}

--- a/tests/scripttest.py
+++ b/tests/scripttest.py
@@ -43,6 +43,28 @@ set_print_ir(False)
 print("The OS name is ", get_os_name(), ". The target bit width is ", get_target_bits())
 
 assert_ok('''
+{@from bdutils import *@}
+dim a = {@set_int(234)@}
+dim b = {@set_str("hello")@}
+dim c as {@resolve_set_type("int")@}
+struct p[...]
+	public v1 as {@cls_templ_type_at(0)@}
+	public v2 as {@cls_templ_type_at(1)@}
+end
+dim pv as p[int,string]
+''')
+
+
+assert_fail('''
+{@from bdutils import *@}
+struct p[...]
+	public v1 as {@cls_templ_type_at(10)@}
+	public v2 as {@cls_templ_type_at(1)@}
+end
+dim pv as p[int,string]
+''')
+
+assert_ok('''
 dim a as string[] = new string *32
 dim b as {@set_type(resolve_type("int"))@}[] =new int * 32
 ''')

--- a/tests/scripttest.py
+++ b/tests/scripttest.py
@@ -43,6 +43,29 @@ set_print_ir(False)
 print("The OS name is ", get_os_name(), ". The target bit width is ", get_target_bits())
 
 assert_ok('''
+dim a as string[] = new string *32
+dim b as {@set_type(resolve_type("int"))@}[] =new int * 32
+''')
+
+assert_ok('''
+import variant:variant
+dim v as variant[{@set_type(resolve_type("int"))@}]
+''')
+
+assert_generate_ok('''
+class clsbase [Arg as int, T1,T2]
+	public a as T1
+	public b as T2
+end
+
+class clsderived [T1] : clsbase[{@set_ast(NumberExprAST.new(BasicType.INT,32))@}, T1,{@set_type(resolve_type("float"))@}]
+	public c as T1
+end
+
+dim a = new clsderived[int]
+''')
+
+assert_ok('''
 import variant:variant
 dim v as variant[byte,int,long,string]
 v.set(1)


### PR DESCRIPTION
This PR mainly focuses on script feature enhancement.

1. Bug fix on type_info class generation and add hardware exception to be caught by try-catch

2. Template arguments now supports scripts (can either generates a type or an constant expr)

3. Script enhancement: add bdutils

I have added many handy utility functions in bdutils. E.g. You can easily convert a Python string to a Birdee compile-time string by:

```vb
dim a as string = {@set_str(raw_input())@} 
```

You can easily generate i-th template argument by Python functions "get\_cls\_templ\_type\_at(i)" and "get\_cls\_templ\_type\_at(i)". Or you can further use "cls\_templ\_type\_at(i)" and "cls\_templ\_type\_at(i)" to get the template argument and set to the current AST.

4. You can call a python function generator in annotation

We can now write something like:

```vb
@route("/hello/{name}")
function handle_hello(name as string) as string => "hello " + name
``` 

Where "route" is a py function that generates a py function

4. Traits are enhanced

I have introduced "require" Python function in traits. It is useful for checking the types for templates and can be used in annotations. The Usage is:

```python
require( check1, check2, ....)
```

where "checkN" is a python tuple of (checking_function_name, arguments...)

e.g., 

```vb
{@from traits import *
from traits import _
@}

@require((is_cls_template_inst, _), (is_type_templ_arg_in_class, _, 0))
struct p[...]
	public v1 as {@cls_templ_type_at(0)@}
	public v2 as {@cls_templ_type_at(1)@}
end
```

The annotation above p\[...\] checks if the instance of template is an template instance and if its 0-th template argument is a type. The functions

```
is_type_templ_arg_in_class
is_cls_template_inst
```

are defined in traits. The first argument of these two functions are the class AST to be checked. Since annotations are called outside of a ClassAST, the function “get\_cur\_class" will not work. But in "require", you can use underscore "\_" as the current AST node (FunctionAST or ClassAST, or others)

You can use AND(tuple1, tuple2),  OR(tuple1, tuple2), NOT(func, args...) to combine the requirements.

```vb
@require(AND(NOT(is_cls_template_inst, _), (is_type_templ_arg_in_class, _, 0)))
struct p[...]
end
```


