### PR TITLE
Implement concurrent.threading

### DIFF
--- a/Birdee/CodeGen.cpp
+++ b/Birdee/CodeGen.cpp
@@ -1335,10 +1335,11 @@ llvm::Value * Birdee::FunctionAST::Generate()
 				auto var = v.second.get();
 				DIType* ty = helper.GetTypeNode(var->resolved_type).dty;
 				assert(v.second->capture_import_type != VariableSingleDefAST::CAPTURE_NONE);
+				int impidx = v.second->capture_import_idx;
 				if(v.second->capture_import_type==VariableSingleDefAST::CAPTURE_VAL)
-					var->llvm_value = builder.CreateGEP(imported_capture_pointer, { builder.getInt32(0),builder.getInt32(idx) }, var->name);
+					var->llvm_value = builder.CreateGEP(imported_capture_pointer, { builder.getInt32(0),builder.getInt32(impidx) }, var->name);
 				else
-					var->llvm_value = builder.CreateLoad(builder.CreateGEP(imported_capture_pointer, { builder.getInt32(0),builder.getInt32(idx) }), var->name);
+					var->llvm_value = builder.CreateLoad(builder.CreateGEP(imported_capture_pointer, { builder.getInt32(0),builder.getInt32(impidx) }), var->name);
 				// Create a debug descriptor for the variable.
 				DILocalVariable *D = DBuilder->createAutoVariable(dinfo.LexicalBlocks.back(), var->name, dinfo.cu->getFile(), var->Pos.line, ty,
 					true);

--- a/Birdee/CodeGen.cpp
+++ b/Birdee/CodeGen.cpp
@@ -1210,7 +1210,7 @@ llvm::Value * Birdee::NewExprAST::Generate()
 	}
 
 	if(func)
-		GenerateCall(func->decl->llvm_func, func->decl->Proto.get(), ret, args, this->Pos);
+		GenerateCall(func->llvm_func, func->Proto.get(), ret, args, this->Pos);
 	return ret;
 }
 

--- a/Birdee/CodeGen.cpp
+++ b/Birdee/CodeGen.cpp
@@ -361,6 +361,23 @@ llvm::Type* BuildArrayType(llvm::Type* ty, DIType* & dty,string& name,DIType* & 
 
 }
 
+static void GenerateClosureTypes(llvm::Type* functy, DIType* funcdty, llvm::Type*& outbase, DIType*& outdtype, int lineno)
+{
+	outbase = StructType::create({ functy,builder.getInt8PtrTy() });
+	auto size = module->getDataLayout().getTypeAllocSizeInBits(outbase);
+	auto align = module->getDataLayout().getPrefTypeAlignment(outbase);
+
+	DIFile *Unit = DBuilder->createFile(dinfo.cu->getFilename(),
+		dinfo.cu->getDirectory());
+	SmallVector<Metadata *, 8> dtypes = { 
+		DBuilder->createMemberType(dinfo.cu,"pfunc",Unit,1,64,align*8,0,DINode::DIFlags::FlagZero, funcdty) ,
+		DBuilder->createMemberType(dinfo.cu,"pclosure",Unit,1,64,align * 8,64,DINode::DIFlags::FlagZero,
+		DBuilder->createBasicType("pointer",64,dwarf::DW_ATE_address))
+	};
+	outdtype = DBuilder->createStructType(dinfo.cu, "", Unit, lineno, size, align * 8, DINode::DIFlags::FlagZero, nullptr, DBuilder->getOrCreateArray(dtypes));
+
+}
+
 void GenerateType(const Birdee::ResolvedType& type, PDIType& dtype, llvm::Type* & base)
 {
 	if (type.index_level > 0)
@@ -428,7 +445,6 @@ void GenerateType(const Birdee::ResolvedType& type, PDIType& dtype, llvm::Type* 
 	{
 		auto functy = type.proto_ast->GenerateFunctionType()->getPointerTo();
 		auto funcdty = type.proto_ast->GenerateDebugType();
-
 		if (!type.proto_ast->is_closure)
 		{
 			base = functy;
@@ -436,18 +452,7 @@ void GenerateType(const Birdee::ResolvedType& type, PDIType& dtype, llvm::Type* 
 		}
 		else
 		{
-			base = StructType::create({ functy,builder.getInt8PtrTy() });
-			auto size = module->getDataLayout().getTypeAllocSizeInBits(base);
-			auto align = module->getDataLayout().getPrefTypeAlignment(base);
-
-			DIFile *Unit = DBuilder->createFile(dinfo.cu->getFilename(),
-				dinfo.cu->getDirectory());
-			SmallVector<Metadata *, 8> dtypes = { 
-				DBuilder->createMemberType(dinfo.cu,"pfunc",Unit,1,64,align*8,0,DINode::DIFlags::FlagZero, funcdty) ,
-				DBuilder->createMemberType(dinfo.cu,"pclosure",Unit,1,64,align * 8,64,DINode::DIFlags::FlagZero,
-					DBuilder->createBasicType("pointer",64,dwarf::DW_ATE_address))
-			};
-			dtype = DBuilder->createStructType(dinfo.cu, "", Unit, type.proto_ast->pos.line, size, align * 8, DINode::DIFlags::FlagZero, nullptr, DBuilder->getOrCreateArray(dtypes));
+			GenerateClosureTypes(functy, funcdty, base, dtype, type.proto_ast->pos.line);
 		}
 		break;
 	}
@@ -1075,7 +1080,8 @@ DIType* Birdee::FunctionAST::PreGenerate()
 	else
 		linkage = Function::ExternalLinkage;
 	MangleNameAndAppend(prefix, Proto->GetName());
-	auto myfunc = Function::Create(Proto->GenerateFunctionType(), linkage, prefix, module);
+	auto ftype=Proto->GenerateFunctionType();
+	auto myfunc = Function::Create(ftype, linkage, prefix, module);
 	llvm_func = myfunc;
 	if (strHasEnding(cu.targetpath,".obj") && (Proto->cls && Proto->cls->isTemplateInstance() || isTemplateInstance))
 	{
@@ -1083,7 +1089,22 @@ DIType* Birdee::FunctionAST::PreGenerate()
 		myfunc->setDSOLocal(true);
 	}
 	DIType* ret = Proto->GenerateDebugType();
-	helper.typemap[resolved_type].dty = ret;
+	auto itr = helper.typemap.find(resolved_type);
+	if(itr==helper.typemap.end())
+	{
+		LLVMHelper::TypePair tynode;
+		if(resolved_type.proto_ast->is_closure)
+		{
+			GenerateClosureTypes(ftype->getPointerTo(),ret,tynode.llvm_ty, tynode.dty, Pos.line);
+		}
+		else
+		{
+			tynode.dty = ret;
+			tynode.llvm_ty = ftype->getPointerTo();
+		}
+		helper.typemap.insert(std::make_pair(resolved_type,tynode));
+	}
+
 	return ret;
 }
 
@@ -1264,7 +1285,6 @@ llvm::Value * Birdee::FunctionAST::Generate()
 	{
 		return nullptr;
 	}
-	
 	ImportedModule* mod = nullptr;
 	if (isTemplateInstance && template_source_func->template_param->mod)
 		mod = template_source_func->template_param->mod;

--- a/Birdee/CopyAST.cpp
+++ b/Birdee/CopyAST.cpp
@@ -397,7 +397,7 @@ namespace Birdee
 	}
 	unique_ptr<StatementAST> Birdee::ScriptAST::Copy()
 	{
-		auto ret = make_unique<ScriptAST>(script);
+		auto ret = make_unique<ScriptAST>(script, is_top_level);
 		ret->Pos = Pos;
 		if (stmt)
 			ret->stmt = stmt->Copy();

--- a/Birdee/MetadataDeserializer.cpp
+++ b/Birdee/MetadataDeserializer.cpp
@@ -701,7 +701,7 @@ void ImportedModule::Init(const vector<string>& package, const string& module_na
 			BirdeeAssert(itr->is_string(), "InitScripts field in bmm file should be a string");
 			//if it has a init script, construct a temp ScriptAST and run it
 			Birdee::PushPyScope(this);
-			ScriptAST tmp= ScriptAST(string());
+			ScriptAST tmp= ScriptAST(string(), true);
 			tmp.script = itr->get<string>();
 			if (!tmp.script.empty())
 			{

--- a/Birdee/MetadataDeserializer.cpp
+++ b/Birdee/MetadataDeserializer.cpp
@@ -301,6 +301,12 @@ void BuildSingleClassFromJson(ClassAST* ret, const json& json_cls, int module_id
 	}
 	ret->name = json_cls["name"].get<string>();
 	ret->package_name_idx = module_idx;
+	
+	{
+		auto itr = json_cls.find("is_struct");
+		if(itr!=json_cls.end())
+			ret->is_struct = itr->get<bool>();
+	}
 	const json& json_fields = json_cls["fields"];
 	BirdeeAssert(json_fields.is_array(), "Expected an JSON array");
 	int idx = 0;

--- a/Birdee/MetadataSerializer.cpp
+++ b/Birdee/MetadataSerializer.cpp
@@ -332,6 +332,7 @@ json BuildSingleClassJson(ClassAST& cls, bool dump_qualified_name)
 	json json_cls;
 	json_cls["name"] = dump_qualified_name ? cls.GetUniqueName() : cls.name;
 	json_cls["needs_rtti"] = cls.needs_rtti;
+	json_cls["is_struct"] = cls.is_struct;
 	if (cls.isTemplate())
 	{
 		assert(!cls.template_param->source.empty());

--- a/Birdee/Parser.cpp
+++ b/Birdee/Parser.cpp
@@ -633,7 +633,7 @@ std::unique_ptr<ExprAST> ParsePrimaryExpression()
 		return nullptr;
 		break;
 	case tok_script:
-		push_expr(make_unique<ScriptAST>(tokenizer.IdentifierStr));
+		push_expr(make_unique<ScriptAST>(tokenizer.IdentifierStr, false));
 		tokenizer.GetNextToken();
 		break;
 	default:
@@ -1699,7 +1699,7 @@ void ParseImports(bool need_do_import)
 	}
 }
 
-BD_CORE_API unique_ptr<StatementAST> ParseStatement()
+BD_CORE_API unique_ptr<StatementAST> ParseStatement(bool is_top_level)
 {
 	unique_ptr<StatementAST> ret;
 	switch (tokenizer.CurTok)
@@ -1733,6 +1733,19 @@ BD_CORE_API unique_ptr<StatementAST> ParseStatement()
 		tokenizer.GetNextToken();
 		ret = make_unique<ThrowAST>(ParseExpressionUnknown(), pos);
 		CompileExpect({ tok_newline,tok_eof }, "Expected a new line after throw");
+		break;
+	}
+	case tok_declare:
+	{
+		tokenizer.GetNextToken(); //eat declare
+		CompileExpect(tok_func, "Expected a function after declare");
+		CompileAssert(is_top_level, "Can only parse function declaration in top-level");
+		std::unique_ptr<FunctionAST> funcast = ParseDeclareFunction(nullptr);
+		std::reference_wrapper<const string> funcname = funcast->GetName();
+		std::reference_wrapper<FunctionAST> funcref = *funcast;
+		CompileCheckGlobalConflict(funcast->Pos, funcname);
+		cu.funcmap.insert(std::make_pair(funcname, funcref));
+		ret = std::move(funcast);
 		break;
 	}
 	default:
@@ -1876,7 +1889,10 @@ BD_CORE_API int ParseTopLevel()
 			CompileExpect({ tok_newline,tok_eof }, "Expected a new line after class definition");
 			break;
 		}
-
+		case tok_script:
+			push_expr(make_unique<ScriptAST>(tokenizer.IdentifierStr,true));
+			tokenizer.GetNextToken();
+			break;
 		default:
 			firstexpr = ParseExpressionUnknown();
 			BasicBlockCheckUnknownToken({ tok_eof,tok_newline });

--- a/Birdee/Preprocessing.cpp
+++ b/Birdee/Preprocessing.cpp
@@ -489,7 +489,7 @@ public:
 					//then create a variable to import the variable
 					var->capture_import_type = v->capture_export_type;
 					var->capture_import_idx = v->capture_export_idx;
-					var->capture_export_idx = VariableSingleDefAST::CAPTURE_NONE;
+					var->capture_export_type = VariableSingleDefAST::CAPTURE_NONE;
 					var->capture_export_idx = -1;
 
 					//v is set to be the imported variable for the next iteration

--- a/Birdee/PythonBinding2.cpp
+++ b/Birdee/PythonBinding2.cpp
@@ -16,10 +16,11 @@ extern int ParseTopLevel();
 extern std::reference_wrapper<FunctionAST> GetCurrentPreprocessedFunction();
 BD_CORE_API std::reference_wrapper<ClassAST> GetCurrentPreprocessedClass();
 extern std::unique_ptr<Type> ParseTypeName();
-extern unique_ptr<StatementAST> ParseStatement();
+extern unique_ptr<StatementAST> ParseStatement(bool is_top_level);
 
 static unique_ptr<StatementAST> outexpr = nullptr;
 static ResolvedType outtype;
+static ScriptAST* cur_script_ast = nullptr;
 
 extern BD_CORE_API Tokenizer tokenizer;
 
@@ -131,6 +132,7 @@ BIRDEE_BINDING_API void* BirdeeGetOrigScope()
 
 BIRDEE_BINDING_API void Birdee_ScriptAST_Phase1(ScriptAST* ths, void* globals, void* locals)
 {
+	cur_script_ast = ths;
 	auto& env=InitPython();
 	try
 	{
@@ -156,6 +158,7 @@ BIRDEE_BINDING_API void Birdee_ScriptAST_Phase1(ScriptAST* ths, void* globals, v
 	}
 	outexpr = nullptr;
 	outtype = ResolvedType();
+	cur_script_ast = nullptr;
 }
 
 static UniquePtrStatementAST CompileExpr(char* cmd) {
@@ -171,7 +174,7 @@ static UniquePtrStatementAST CompileStmt(char* cmd) {
 	Birdee::Tokenizer toknzr(std::make_unique<Birdee::StringStream>(std::string(cmd)), -1);
 	toknzr.GetNextToken();
 	auto old_tok = SwitchTokenizer(std::move(toknzr));
-	auto stmt = ParseStatement();
+	auto stmt = ParseStatement(cur_script_ast ? cur_script_ast->is_top_level: false);
 	SwitchTokenizer(std::move(old_tok));
 	return UniquePtrStatementAST(std::move(stmt));
 }
@@ -546,7 +549,7 @@ void RegisiterClassForBinding(py::module& m)
 		.def("run", [](MemberExprAST& ths, py::object& func) {func(GetRef(ths.Obj)); });
 
 	py::class_ < ScriptAST, ExprAST>(m, "ScriptAST")
-		.def_static("new", [](const string& str) { return new UniquePtrStatementAST(std::make_unique<ScriptAST>(str)); })
+		.def_static("new", [](const string& str, bool is_top_level) { return new UniquePtrStatementAST(std::make_unique<ScriptAST>(str, is_top_level)); })
 		.def_property("stmt", [](ScriptAST& ths) {return GetRef(ths.stmt); }, [](ScriptAST& ths, UniquePtrStatementAST& v) {
 			ths.stmt = v.move_expr();
 		})

--- a/Birdee/include/BdAST.h
+++ b/Birdee/include/BdAST.h
@@ -761,24 +761,7 @@ namespace Birdee {
 			ExprAST::print(level + 1); std::cout << "----------------\n";
 		}
 	};
-// 	class BD_CORE_API AddressOfExprAST : public ExprAST {
-// 	public:
-// 		std::unique_ptr<ExprAST> expr;
-// 		bool is_address_of; //true for addressof, false for pointerof
-// 		void Phase1();
-// 		std::unique_ptr<StatementAST> Copy();
-// 		llvm::Value* Generate();
-// 		AddressOfExprAST(unique_ptr<ExprAST>&& Expr, bool is_address_of, SourcePos Pos)
-// 			: expr(std::move(Expr)), is_address_of(is_address_of){
-// 			this->Pos = Pos;
-// 		}
-// 		void print(int level) {
-// 			ExprAST::print(level);
-// 			std::cout << "AddressOf\n";
-// 			expr->print(level + 1);
-//			
-// 		}
-// 	};
+
 	/// CallExprAST - Expression class for function calls.
 	class BD_CORE_API CallExprAST : public ExprAST {
 	public:
@@ -1197,7 +1180,7 @@ namespace Birdee {
 		string method;
 	public:
 		vector<std::unique_ptr<ExprAST>> args;
-		MemberFunctionDef* func = nullptr;
+		FunctionAST* func = nullptr;
 		std::unique_ptr<StatementAST> Copy();
 		void Phase1();
 		llvm::Value* Generate();
@@ -1212,23 +1195,6 @@ namespace Birdee {
 
 		}
 	};
-// 	class BD_CORE_API TypeofExprAST : public ExprAST {
-// 	public:
-// 		unique_ptr<ExprAST> arg;
-// 		std::unique_ptr<StatementAST> Copy();
-// 		//first resolve variables then resolve class names
-// 		void Phase1();
-// 		llvm::Value* Generate();
-// 		TypeofExprAST(unique_ptr<ExprAST>&& arg, SourcePos Pos)
-// 			: arg(std::move(arg)) {
-// 			this->Pos = Pos;
-// 		}
-// 		void print(int level) {
-// 			ExprAST::print(level);
-// 			std::cout << "typeof \n";
-// 			arg->print(level+1);
-//			}
-//		};
 
 	class BD_CORE_API ClassAST : public StatementAST {
 	public:
@@ -1355,6 +1321,7 @@ namespace Birdee {
 		ResolvedType type_data;
 		//In most cases, ScriptAST is used as a general expr.
 		unique_ptr<StatementAST> stmt;
+		bool is_top_level;
 		string script;
 		virtual Value* Generate();
 		virtual void Phase1();
@@ -1363,7 +1330,7 @@ namespace Birdee {
 			ExprAST::print(level);
 			std::cout << "script " << script<<"\n";
 		}
-		ScriptAST(const string& str):script(str) {}
+		ScriptAST(const string& str, bool is_top_level):script(str), is_top_level(is_top_level){}
 		virtual llvm::Value* GetLValue(bool checkHas);
 	};
 

--- a/BirdeeHome/pylib/bbuild.py
+++ b/BirdeeHome/pylib/bbuild.py
@@ -245,11 +245,14 @@ def prepare_module(modu,is_main):
 		if proc.wait()!=0:
 			raise RuntimeError("Compile failed, exit code: "+ str(proc.returncode))
 		proc=None #hope to release resource for the process pipe
+		module_set=set()
 		for depstr in dependencies_list:
 			dep=depstr.split(".")
 			if dep[-1][0]==':' or dep[-1][0]=='*':  #if it is a "name import"
 				dep.pop() #delete the imported name
-			cu.add_dependency(prepare_module(dep,False))
+			module_set.add(tuple(dep)) #use a set to remove duplications
+		for dep in module_set:
+			cu.add_dependency(prepare_module(list(dep),False))
 		create_dirs(outpath,modu)
 	return cu
 
@@ -342,7 +345,7 @@ while True:
 
 for modu,cu in prepared_mod.items():
 	if not cu.done:
-		raise RuntimeError("The compile unit " + ".".join(cu.modu) + " is not compiled")
+		raise RuntimeError("The compile unit " + ".".join(cu.modu) + " is not compiled. Dependency cnt = ", cu.dependency_cnt)
 
 if link_executable and link_target:
 	if os.path.exists(link_target) and os.path.isfile(link_target) and  os.path.getmtime(link_target)>max_bin_timestamp:

--- a/BirdeeHome/pylib/bdutils.py
+++ b/BirdeeHome/pylib/bdutils.py
@@ -39,6 +39,12 @@ def make_str(s):
 def set_str(s):
 	set_ast(make_str(s))
 
+def set_expr(s):
+	set_ast(expr(s))
+
+def set_stmt(s):
+	set_ast(stmt(s))
+
 def resolve_set_type(s):
 	set_type(resolve_type(s))
 

--- a/BirdeeHome/pylib/bdutils.py
+++ b/BirdeeHome/pylib/bdutils.py
@@ -64,3 +64,9 @@ def cls_templ_type_at(idx):
 
 def cls_templ_expr_at(idx):
 	set_ast(get_cls_expr_templ_at(idx))
+
+#utilities for functions
+def get_function_arg_at(func,idx):
+	args = func.proto.args
+	require_(index_within(idx,0,len(args)))
+	return args[idx]

--- a/BirdeeHome/pylib/traits.py
+++ b/BirdeeHome/pylib/traits.py
@@ -94,11 +94,11 @@ def is_expr_templ_arg(args,idx):
 Check if "type" is a prototype. Throw if not.
  - type: The ResolvedType to check
 '''
-def check_is_prototype(ctype):
-	if ctype.base!=BasicType.FUNC or ctype.index_level!=0:
-		raise RuntimeError("The type {} is not a function prototype".format(str(ctype)))
-
 def is_prototype(ctype):
+	return (ctype.base==BasicType.FUNC and ctype.index_level==0,
+		lambda:"The type {} is not a function prototype".format(str(ctype)) )
+
+def is_prototype_(ctype):
 	return ctype.base==BasicType.FUNC and ctype.index_level==0
 
 '''
@@ -110,7 +110,7 @@ Returns the resolvedtype of what the function returns
 '''
 def return_type_of(expr):
 	proto = expr.resolved_type
-	check_is_prototype(proto)
+	require_(is_prototype_(proto))
 	return proto.get_detail().return_type
 
 '''

--- a/BirdeeHome/src/Makefile
+++ b/BirdeeHome/src/Makefile
@@ -6,7 +6,7 @@ BLIB_DIR=$(PARENT_DIR)/blib
 BIN=$(PARENT_DIR)/bin
 LIB=$(PARENT_DIR)/lib
 
-all: ${BLIB_DIR}/birdee.o ${BLIB_DIR}/variant.o ${BLIB_DIR}/list.o ${BLIB_DIR}/hash_map.o ${BLIB_DIR}/hash_set.o ${LIB} ${BLIB_DIR}/tuple.o ${BLIB_DIR}/fmt.o ${BLIB_DIR}/vector.o ${BLIB_DIR}/queue.o ${BLIB_DIR}/stack.o ${BLIB_DIR}/unsafe.o
+all: ${BLIB_DIR}/birdee.o libs
 
 print-%  : ; @echo $* = $($*)
 
@@ -24,35 +24,8 @@ ${BLIB_DIR}:
 ${BLIB_DIR}/birdee.o: birdee.txt ${BLIB_DIR} ${BIN}
 	$(BIN)/birdeec --corelib -i birdee.txt -o $(BLIB_DIR)/birdee.o
 
-${BLIB_DIR}/list.o: list.txt ${BLIB_DIR}/birdee.o
-	$(BIN)/birdeec -i list.txt -o $(BLIB_DIR)/list.o
-
-${BLIB_DIR}/hash_map.o: hash_map.txt ${BLIB_DIR}/birdee.o
-	$(BIN)/birdeec -i hash_map.txt -o $(BLIB_DIR)/hash_map.o
-
-${BLIB_DIR}/hash_set.o: hash_set.txt ${BLIB_DIR}/birdee.o
-	$(BIN)/birdeec -i hash_set.txt -o $(BLIB_DIR)/hash_set.o
-
-${BLIB_DIR}/tuple.o: tuple.txt ${BLIB_DIR}/birdee.o
-	$(BIN)/birdeec -i tuple.txt -o $(BLIB_DIR)/tuple.o
-
-${BLIB_DIR}/fmt.o: fmt.txt ${BLIB_DIR}/birdee.o
-	$(BIN)/birdeec -i fmt.txt -o $(BLIB_DIR)/fmt.o
-
-${BLIB_DIR}/vector.o: vector.txt ${BLIB_DIR}/birdee.o
-	$(BIN)/birdeec -i vector.txt -o $(BLIB_DIR)/vector.o
-
-${BLIB_DIR}/queue.o: queue.txt ${BLIB_DIR}/birdee.o
-	$(BIN)/birdeec -i queue.txt -o $(BLIB_DIR)/queue.o
-
-${BLIB_DIR}/stack.o: stack.txt ${BLIB_DIR}/birdee.o
-	$(BIN)/birdeec -i stack.txt -o $(BLIB_DIR)/stack.o
-
-${BLIB_DIR}/unsafe.o: unsafe.txt ${BLIB_DIR}/birdee.o
-	$(BIN)/birdeec -i unsafe.txt -o $(BLIB_DIR)/unsafe.o
-
-${BLIB_DIR}/variant.o: variant.txt ${BLIB_DIR}/birdee.o ${BLIB_DIR}/unsafe.o
-	$(BIN)/birdeec -i variant.txt -o $(BLIB_DIR)/variant.o
+libs: ${BLIB_DIR}/birdee.o
+	python3 $(PARENT_DIR)/pylib/bbuild.py -i . -o ${BLIB_DIR} test variant list hash_map hash_set tuple fmt vector queue stack unsafe
 
 clean:
 	rm -rf ${BLIB_DIR}

--- a/BirdeeHome/src/Makefile
+++ b/BirdeeHome/src/Makefile
@@ -25,7 +25,7 @@ ${BLIB_DIR}/birdee.o: birdee.txt ${BLIB_DIR} ${BIN}
 	$(BIN)/birdeec --corelib -i birdee.txt -o $(BLIB_DIR)/birdee.o
 
 libs: ${BLIB_DIR}/birdee.o
-	python3 $(PARENT_DIR)/pylib/bbuild.py -i . -o ${BLIB_DIR} test variant list hash_map hash_set tuple fmt vector queue stack unsafe
+	python3 $(PARENT_DIR)/pylib/bbuild.py -i . -o ${BLIB_DIR} test variant list hash_map hash_set tuple fmt vector queue stack unsafe concurrent.threading
 
 clean:
 	rm -rf ${BLIB_DIR}

--- a/BirdeeHome/src/concurrent/threading.bdm
+++ b/BirdeeHome/src/concurrent/threading.bdm
@@ -1,0 +1,79 @@
+package concurrent
+
+import unsafe
+
+struct closure_unpacked
+	public funcptr as pointer
+	public data as pointer
+end
+
+@init_script
+{@
+from traits import *
+from traits import _
+from bdutils import *
+
+def check_arg_is_functype(idx):
+	def checker(fn):
+		ty = get_function_arg_at(fn,0).resolved_type
+		require_(is_prototype(ty))
+	return checker
+
+def check_arg_is_closure(idx):
+	def checker(fn):
+		ty = get_function_arg_at(fn,0).resolved_type
+		require_(is_prototype(ty))
+		require_( (ty.get_detail().is_closure, lambda:"Expecting a closure"))
+	return checker
+
+def expand_vararg(func, idx_start):
+	args = func.proto.args
+	ret = ""
+	for i in range(idx_start,len(args)):
+		ret+= args[i].name+','
+	return ret[:-1]
+@}
+
+@check_arg_is_closure(0)
+function unpack_closure[T](f as T) as closure_unpacked => unsafe.ptr_load[closure_unpacked](addressof(f))
+
+declare function pthread_create(ptr_thread_id as pointer, attr as pointer, routine as pointer, arg as pointer) as int
+declare function pthread_exit(p as pointer)
+
+function pthread_create_wrapper(ptr_thread_id as pointer, attr as pointer, routine as pointer, arg as pointer) as int => pthread_create(ptr_thread_id,attr,routine,arg)
+function pthread_exit_wrapper(p as pointer) => pthread_exit(p)
+
+
+class thread
+	private handle as pointer
+
+	public function init[T,...](fn as T, ...)
+{@
+func=get_cur_func()
+check_arg_is_functype(0)(func)
+@}
+		dim f = function ()
+			{@set_ast(expr("fn({})".format(expand_vararg(func,1))))@}
+			pthread_exit_wrapper(pointerof(null))
+		end
+		dim unpacked = unpack_closure(f)
+		pthread_create_wrapper(addressof(handle),pointerof(null),unpacked.funcptr,unpacked.data)
+	end
+end
+
+
+##func aaaa()
+	dim a as int
+	dim b = func()
+		a
+		println("hi")
+	end
+	dim clo = unpack_closure(b)
+	println(pointer2str(clo.data))
+	println(pointer2str(clo.funcptr))
+end
+
+aaaa()##
+
+
+

--- a/BirdeeHome/src/concurrent/threading.bdm
+++ b/BirdeeHome/src/concurrent/threading.bdm
@@ -13,6 +13,7 @@ from traits import *
 from traits import _
 from bdutils import *
 
+osname =  get_os_name()
 def check_arg_is_functype(idx):
 	def checker(fn):
 		ty = get_function_arg_at(fn,0).resolved_type
@@ -37,27 +38,72 @@ def expand_vararg(func, idx_start):
 @check_arg_is_closure(0)
 function unpack_closure[T](f as T) as closure_unpacked => unsafe.ptr_load[closure_unpacked](addressof(f))
 
-declare function pthread_create(ptr_thread_id as pointer, attr as pointer, routine as pointer, arg as pointer) as int
-declare function pthread_exit(p as pointer)
+{@
+os_function_decl = {
+	'windows':{
+		'create':'declare function CreateThread(lpThreadAttributes as pointer, dwStackSize as ulong, lpStartAddress as pointer, arg as pointer, dwCreationFlags as int, lpThreadId as pointer) as pointer',
+		'exit': 'declare function ExitThread(status as int)',
+		'sleep': 'declare function Sleep(ms as int)'
+	},
+	'linux':{
+		'create':'declare function pthread_create(ptr_thread_id as pointer, attr as pointer, routine as pointer, arg as pointer) as int',
+		'exit': 'declare function pthread_exit(p as pointer)',
+		'sleep': 'declare function Sleep alias "sleep" (seconds as int) '
+	}
+}
+set_ast(stmt(os_function_decl[osname]['create']))
+@}
+{@set_ast(stmt(os_function_decl[osname]['exit']))@}
+{@set_ast(stmt(os_function_decl[osname]['sleep']))@}
 
-function pthread_create_wrapper(ptr_thread_id as pointer, attr as pointer, routine as pointer, arg as pointer) as int => pthread_create(ptr_thread_id,attr,routine,arg)
-function pthread_exit_wrapper(p as pointer) => pthread_exit(p)
+function sleep(ms as int)
+	ms = ms / {@
+if osname=='windows':
+	set_int(1)
+else:
+	set_int(1000)
+@}
+	Sleep(ms)
+end
 
+function do_create_thread(routine as pointer, arg as pointer) as pointer
+	dim ret as pointer
+{@
+if osname=='windows':
+	set_ast(expr("ret=CreateThread(pointerof(null),0,routine,arg,0,pointerof(null))"))
+elif osname=='linux':
+	set_ast(expr("pthread_create(addressof(ret),pointerof(null),routine,arg)"))
+else:
+	assert(False)
+@}
+	return ret
+end
+
+function do_exit_thread()
+{@
+if osname=='windows':
+	set_expr("ExitThread(0)")
+elif osname=='linux':
+	set_expr("pthread_exit(pointerof(null))")
+else:
+	assert(False)
+@}
+end
 
 class thread
 	private handle as pointer
 
-	public function init[T,...](fn as T, ...)
+	public function __init__[T,...](fn as T, ...)
 {@
 func=get_cur_func()
 check_arg_is_functype(0)(func)
 @}
 		dim f = function ()
 			{@set_ast(expr("fn({})".format(expand_vararg(func,1))))@}
-			pthread_exit_wrapper(pointerof(null))
+			{@if osname=='linux': set_ast(expr("do_exit_thread()"))@}		
 		end
 		dim unpacked = unpack_closure(f)
-		pthread_create_wrapper(addressof(handle),pointerof(null),unpacked.funcptr,unpacked.data)
+		handle = do_create_thread(unpacked.funcptr,unpacked.data)
 	end
 end
 

--- a/CoreLibs/makefile2.mak
+++ b/CoreLibs/makefile2.mak
@@ -1,4 +1,4 @@
-all: birdee list hash_map hash_set vector queue stack tuple fmt unsafe variant
+all: birdee libs
 BLIB_DIR=$(BIRDEE_HOME)\blib
 
 $(BLIB_DIR):
@@ -6,35 +6,8 @@ $(BLIB_DIR):
 birdee: $(BLIB_DIR) $(BIRDEE_HOME)\src\birdee.txt
 	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\birdee.txt -o $(BIRDEE_HOME)\blib\birdee.obj --corelib
 
-list: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\list.txt
-	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\list.txt -o $(BIRDEE_HOME)\blib\list.obj
-
-hash_map: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\hash_map.txt
-	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\hash_map.txt -o $(BIRDEE_HOME)\blib\hash_map.obj
-
-hash_set: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\hash_set.txt
-	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\hash_set.txt -o $(BIRDEE_HOME)\blib\hash_set.obj
-
-vector: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\vector.txt
-	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\vector.txt -o $(BIRDEE_HOME)\blib\vector.obj
-
-queue: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\queue.txt
-	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\queue.txt -o $(BIRDEE_HOME)\blib\queue.obj
-
-stack: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\stack.txt
-	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\stack.txt -o $(BIRDEE_HOME)\blib\stack.obj
-
-tuple: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\tuple.txt
-	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\tuple.txt -o $(BIRDEE_HOME)\blib\tuple.obj
-
-fmt: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\fmt.txt
-	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\fmt.txt -o $(BIRDEE_HOME)\blib\fmt.obj
-
-unsafe: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\unsafe.txt
-	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\unsafe.txt -o $(BIRDEE_HOME)\blib\unsafe.obj
-
-variant: $(BLIB_DIR) birdee $(BIRDEE_HOME)\src\variant.txt
-	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\variant.txt -o $(BIRDEE_HOME)\blib\variant.obj
+libs: birdee
+	python3 $(BIRDEE_HOME)/pylib/bbuild.py -i $(BIRDEE_HOME)/src -o $(BLIB_DIR) test variant list hash_map hash_set tuple fmt vector queue stack unsafe concurrent.threading
 
 clean:
 	del $(BLIB_DIR)\*.obj

--- a/tests/scripttest.py
+++ b/tests/scripttest.py
@@ -43,6 +43,12 @@ set_print_ir(False)
 print("The OS name is ", get_os_name(), ". The target bit width is ", get_target_bits())
 
 assert_ok('''
+{@set_ast(stmt("declare function getc() as int"))@}
+getc()
+''')
+
+
+assert_ok('''
 {@from bdutils import *
 from traits import *
 from traits import _

--- a/tests/threading_test.bdm
+++ b/tests/threading_test.bdm
@@ -1,13 +1,9 @@
 import concurrent.threading:*
 
-declare function sleep(seconds as int)
-declare function getchar() as int
-
 function add(a as int, b as int)
 	println(int2str(a+b))
 end
 
-dim th = new thread
-th.init(add, 1, 2)
-sleep(10)
+dim th = new thread(add, 1, 2)
+sleep(10000)
 println("end")

--- a/tests/threading_test.bdm
+++ b/tests/threading_test.bdm
@@ -1,0 +1,13 @@
+import concurrent.threading:*
+
+declare function sleep(seconds as int)
+declare function getchar() as int
+
+function add(a as int, b as int)
+	println(int2str(a+b))
+end
+
+dim th = new thread
+th.init(add, 1, 2)
+sleep(10)
+println("end")


### PR DESCRIPTION
Now threading works on Linux and windows. On Linux, you need to add -lc "-lpthread" for bbuild.

Many bug fixes:
1.  Correctly generate function types for type cache
2. Dump is_struct for ClassAST in bmm file
3. Can now resolve& deduce template arguments in NewExprAST's function call

New feature:
1. Allow "declare function ..." in top-level scripts

You can now use threading:
```vb
import concurrent.threading:*

function add(a as int, b as int)
	println(int2str(a+b))
end

dim th = new thread(add, 1, 2)
sleep(10000)
println("end")

```