### PR TITLE
New feature: add typed pointers

### DIFF
--- a/Birdee/Birdee.vcxproj
+++ b/Birdee/Birdee.vcxproj
@@ -175,7 +175,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>BirdeeCompilerCore.lib;BirdeeBinding.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(SolutionDir)dependency/bin/;$(SolutionDir)dependency/bin/llvm-debug;$(SolutionDir)/x64/Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)dependency/bin/;$(SolutionDir)dependency/bin/llvm-debug;$(SolutionDir)/x64/$(Configuration)</AdditionalLibraryDirectories>
       <LinkStatus>false</LinkStatus>
       <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <DelayLoadDLLs>BirdeeBinding.dll</DelayLoadDLLs>
@@ -198,7 +198,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>BirdeeCompilerCore.lib;BirdeeBinding.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(SolutionDir)dependency/bin/;$(SolutionDir)dependency/bin/llvm-debug;$(SolutionDir)/x64/Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)dependency/bin/;$(SolutionDir)dependency/bin/llvm-debug;$(SolutionDir)/x64/$(Configuration)</AdditionalLibraryDirectories>
       <LinkStatus>false</LinkStatus>
       <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <DelayLoadDLLs>BirdeeBinding.dll</DelayLoadDLLs>
@@ -297,6 +297,7 @@
     <None Include="..\BirdeeHome\pylib\traits.py" />
     <None Include="..\BirdeeHome\src\hash.bdm" />
     <None Include="..\BirdeeHome\src\list.bdm" />
+    <None Include="..\BirdeeHome\src\typedptr.bdm" />
     <None Include="..\tests\ast_write_test.py" />
     <None Include="..\tests\getset_test.py" />
     <None Include="..\tests\scripttest.py" />

--- a/Birdee/Birdee.vcxproj.filters
+++ b/Birdee/Birdee.vcxproj.filters
@@ -171,5 +171,8 @@
     <None Include="..\BirdeeHome\src\hash.bdm">
       <Filter>资源文件\blib</Filter>
     </None>
+    <None Include="..\BirdeeHome\src\typedptr.bdm">
+      <Filter>资源文件\blib</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/Birdee/Parser.cpp
+++ b/Birdee/Parser.cpp
@@ -1343,16 +1343,17 @@ void ParseClassInPlace(ClassAST* ret, bool is_struct)
 		ret->template_param->params = std::move(ParseTemplateParameters(ret->template_param->is_vararg, ret->template_param->vararg_name));
 	}
 	// class inherit
-	if (!is_struct) {
-		if (tokenizer.CurTok == tok_colon) {
-			tokenizer.GetNextToken(); // eat colon
-			// CompileExpect(tok_class, "Expected a class as parent"); // eat 'class'
-			// tokenizer.GetNextToken(); 
-			CompileAssert(tokenizer.CurTok == tok_identifier, "Expected a class name");
-			// ret->parent = make_unique<VariableSingleDefAST>(std::move(ParseBasicType()), pos);
-			ret->parent_type = ParseBasicType();
-		}
+	
+	if (tokenizer.CurTok == tok_colon) {
+		CompileAssert(!is_struct, "structs do not support inherience");
+		tokenizer.GetNextToken(); // eat colon
+		// CompileExpect(tok_class, "Expected a class as parent"); // eat 'class'
+		// tokenizer.GetNextToken(); 
+		CompileAssert(tokenizer.CurTok == tok_identifier, "Expected a class name");
+		// ret->parent = make_unique<VariableSingleDefAST>(std::move(ParseBasicType()), pos);
+		ret->parent_type = ParseBasicType();
 	}
+	
 	CompileExpect(tok_newline, "Expected an newline after class name");
 
 	while (true)

--- a/Birdee/PythonBinding2.cpp
+++ b/Birdee/PythonBinding2.cpp
@@ -30,6 +30,7 @@ static void init_embedded_module();
 namespace Birdee
 {
 	extern void ClearPyHandles();
+	BD_CORE_API extern std::pair<int, FieldDef*> FindClassField(ClassAST* class_ast, const string& member);
 }
 
 struct BirdeePyContext
@@ -515,6 +516,10 @@ void RegisiterClassForBinding(py::module& m)
 		.def_property_readonly("is_struct", [](ClassAST& ths) {return ths.is_struct; })
 		.def_readwrite("parent_class", &ClassAST::parent_class)
 		.def("has_parent", &ClassAST::HasParent)
+		.def("find_field", [](ClassAST& cls, const string& member)->auto {
+			auto ret = FindClassField(&cls, member);
+			return py::make_tuple(ret.first, GetRef(ret.second));
+		})
 		.def("run", [](ClassAST& ths, py::object& func) {});//fix-me: what to run on ClassAST?
 //	unordered_map<reference_wrapper<const string>, int> fieldmap;
 //	unordered_map<reference_wrapper<const string>, int> funcmap;

--- a/BirdeeBinding/BirdeeBinding.vcxproj
+++ b/BirdeeBinding/BirdeeBinding.vcxproj
@@ -130,7 +130,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)x64/Debug;$(SolutionDir)dependency/bin/;$(SolutionDir)dependency/bin/llvm-debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)x64/$(Configuration);$(SolutionDir)dependency/bin/;$(SolutionDir)dependency/bin/llvm-debug</AdditionalLibraryDirectories>
       <AdditionalDependencies>python3.lib;BirdeeCompilerCore.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -148,7 +148,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)x64/Debug;$(SolutionDir)dependency/bin/;$(SolutionDir)dependency/bin/llvm-debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)x64/$(Configuration);$(SolutionDir)dependency/bin/;$(SolutionDir)dependency/bin/llvm-debug</AdditionalLibraryDirectories>
       <AdditionalDependencies>python3.lib;BirdeeCompilerCore.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>

--- a/BirdeeHome/pylib/traits.py
+++ b/BirdeeHome/pylib/traits.py
@@ -18,6 +18,9 @@ def is_boolean(rtype):
 def is_a_class(rtype):
 	return rtype.index_level==0 and rtype.base==BasicType.CLASS and  not rtype.get_detail().is_struct
 
+def is_a_struct(rtype):
+	return rtype.index_level==0 and rtype.base==BasicType.CLASS and rtype.get_detail().is_struct
+
 def is_reference(rtype):
 	return rtype.index_level>0 or is_a_class(rtype)
 

--- a/BirdeeHome/src/hash.bdm
+++ b/BirdeeHome/src/hash.bdm
@@ -197,38 +197,48 @@ class hash_map[K,V]
 		return mk_hash_iterator[K,V](node)
 	end
 
+	private function _remove(h as uint, node as hash_node[K,V]) as hash_iterator[K,V]
+		dim cur_idx = h % buckets_num
+		dim lst = buckets[cur_idx]
+		dim prev = get_prev_node(h, node)
+		dim next_idx = 0u
+		dim next = node.next
+		if next!==null then
+			next_idx = next.hash_cache % buckets_num
+		end
+		if prev === lst then
+			#then current node is the first of the bucket
+			if next === null || next_idx != cur_idx then
+				#after removal, the bucket is empty
+				if next!==null then
+					buckets[next_idx] = buckets[cur_idx]
+				end
+				buckets[cur_idx] = null
+			end
+		else if next!==null then
+			#if current node is in the bucket set
+			if next_idx != cur_idx then
+				buckets[next_idx] = prev
+			end
+		end
+		prev.next=node.next
+		lsize = lsize - 1
+		return mk_hash_iterator[K,V](node.next)
+	end
+
+	public function remove_itr(node as hash_iterator[K,V]) as hash_iterator[K,V]
+		dim n = node._node
+		dim h = n.hash_cache
+		return _remove(h, n)
+	end
+
 	public function remove(t as K) as hash_iterator[K,V]
 		dim h = hash[K](t)
 		dim node = do_find(h, t)
 		if node === null then
 			throw new hash_key_excption
 		else
-			dim cur_idx = h % buckets_num
-			dim lst = buckets[cur_idx]
-			dim prev = get_prev_node(h, node)
-			dim next_idx = 0u
-			dim next = node.next
-			if next!==null then
-				next_idx = next.hash_cache % buckets_num
-			end
-			if prev === lst then
-				#then current node is the first of the bucket
-				if next === null || next_idx != cur_idx then
-					#after removal, the bucket is empty
-					if next!==null then
-						buckets[next_idx] = buckets[cur_idx]
-					end
-					buckets[cur_idx] = null
-				end
-			else if next!==null then
-				#if current node is in the bucket set
-				if next_idx != cur_idx then
-					buckets[next_idx] = prev
-				end
-			end
-			prev.next=node.next
-			lsize = lsize - 1
-			return mk_hash_iterator[K,V](node.next)
+			return _remove(h, node)
 		end
 	end
 

--- a/BirdeeHome/src/typedptr.bdm
+++ b/BirdeeHome/src/typedptr.bdm
@@ -1,0 +1,71 @@
+import unsafe:*
+
+#intrinsic
+function sizeof[T]() as ulong
+end
+
+function get_field_ptr[name as string,T2](a as pointer) as pointer
+end
+
+@init_script
+{@
+from traits import *
+from bdutils import *
+
+
+def check_if_T_is_struct():
+	if not is_a_struct(get_cls_type_templ_at(0)):
+		raise RuntimeError("Require T as a struct type")
+
+def get_field_type(field_name):
+	check_if_T_is_struct()
+	T = get_cls_type_templ_at(0)
+	assert(is_a_struct(T))
+	structT = T.get_detail()
+	parents, fielddef = structT.find_field(field_name)
+	if parents==-1:
+		raise RuntimeError("Cannot find field {} in {}".format(field_name, T))
+	set_type(fielddef.decl.resolved_type)
+
+@}
+
+struct ref[T]
+	private ptr as pointer
+	public func set_raw(p as pointer) => ptr = p
+	public func get_raw() => ptr
+
+	
+	public func get() as T => ptr_load[T](ptr)
+	public func set(value as T) => ptr_store[T](ptr, value)
+
+	public func fptr[field as string]() as ref[{@get_field_type(get_func_expr_templ_at(0).value)@}]
+		dim p = get_field_ptr[field, T](ptr)
+		dim ret as {@set_type(get_cur_func().proto.return_type)@}
+		ret.set_raw(p)
+		return ret
+	end
+
+	public func f[field as string]() as {@get_field_type(get_func_expr_templ_at(0).value)@}
+		dim p = get_field_ptr[field, T](ptr)
+		return ptr_load[{@set_type(get_cur_func().proto.return_type)@}](p)
+	end
+
+	public func __eq__(other as ref[T]) as boolean => ptr == other.ptr
+	public func __ne__(other as ref[T]) as boolean => ptr != other.ptr
+
+	public func __add__(offset as int) as ref[T]
+		dim uptr = ptr_cast[ulong](ptr)
+		dim p as pointer = ptr_cast[pointer](uptr + offset * sizeof[T]())
+		dim ret as ref[T]
+		ret.set_raw(p)
+		return ret
+	end
+	
+	public func __sub__(offset as int) as ref[T] => __add__(0-offset)
+end
+
+function mkref[T](p as pointer) as ref[T]
+	dim ret as ref[T]
+	ret.set_raw(p)
+	return ret
+end

--- a/BirdeeHome/src/unsafe.txt
+++ b/BirdeeHome/src/unsafe.txt
@@ -12,4 +12,3 @@ end
 
 function static_cast[T1,T2](a as T2) as T1
 end
-

--- a/BirdeePlayground/BirdeePlayground.vcxproj
+++ b/BirdeePlayground/BirdeePlayground.vcxproj
@@ -133,7 +133,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>BirdeeCompilerCore.lib;BirdeeRuntime.lib;$(BIRDEE_HOME)blib\birdee.obj;$(BIRDEE_HOME)blib\hash_map.obj;$(BIRDEE_HOME)blib\concurrent\threading.obj;$(BIRDEE_HOME)blib\string_buffer.obj;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(SolutionDir)dependency/bin/;$(SolutionDir)dependency/bin/llvm-debug;$(SolutionDir)/x64/Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)dependency/bin/;$(SolutionDir)dependency/bin/llvm-debug;$(SolutionDir)/x64/$(Configuration)</AdditionalLibraryDirectories>
       <ForceSymbolReferences>
       </ForceSymbolReferences>
     </Link>
@@ -157,7 +157,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>BirdeeCompilerCore.lib;BirdeeRuntime.lib;$(BIRDEE_HOME)blib\birdee.obj;$(BIRDEE_HOME)blib\hash_map.obj;$(BIRDEE_HOME)blib\concurrent\threading.obj;$(BIRDEE_HOME)blib\string_buffer.obj;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(SolutionDir)dependency/bin/;$(SolutionDir)dependency/bin/llvm-debug;$(SolutionDir)/x64/Debug</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)dependency/bin/;$(SolutionDir)dependency/bin/llvm-debug;$(SolutionDir)/x64/$(Configuration)</AdditionalLibraryDirectories>
       <ForceSymbolReferences>
       </ForceSymbolReferences>
     </Link>

--- a/tests/typedptr_test.txt
+++ b/tests/typedptr_test.txt
@@ -1,0 +1,57 @@
+import typedptr:*
+
+@enable_rtti
+class assertion_exception
+
+end
+
+{@
+from bdutils import *
+def line_pos():
+	strpos = str(get_cur_script().pos)
+	set_ast(StringLiteralAST.new(strpos))
+@}
+
+function assert(v as boolean, msg as string)
+	if !v then
+		println("Assertion failed :" + msg)
+		throw new assertion_exception
+	end
+end
+
+
+struct mystruct
+	public c as string
+	public a as int
+	public b as int
+end
+
+println("typed ptr test")
+dim a as int =32
+dim a2 as int
+dim b as int[] = [1,2,3,4]
+dim c as mystruct
+
+dim pa = mkref[int](addressof(a))
+assert(pa.get()==32, {@line_pos()@})
+
+pa.set(64)
+assert(a==64, {@line_pos()@})
+assert(pa==mkref[int](addressof(a)), {@line_pos()@})
+pa=mkref[int](addressof(a2))
+assert(pa==mkref[int](addressof(a2)), {@line_pos()@})
+
+pa = mkref[int](addressof(b[0]))
+assert(pa.get()==1, {@line_pos()@})
+pa = pa + 1
+assert(pa.get()==2, {@line_pos()@})
+
+c.a=1
+c.b=2
+c.c="sadas"
+dim pc = mkref[mystruct](addressof(c))
+assert(pc.f["a"]()==1, {@line_pos()@})
+assert(pc.fptr["b"]().get()==2, {@line_pos()@})
+assert(pc.f["c"]()=="sadas", {@line_pos()@})
+println("Should be sadas: " + pc.f["c"]())
+println("test done")


### PR DESCRIPTION
Birdee has already had general pointers, which is designed for interactions with other languages like C and C++. But I think it is not convenient to use general pointers in Birdee. So I add a new module to wrap  general pointers with types, so users can get() and set() the values pointed by the implied general pointer. Moreover, users can get a single field from a pointer to a struct, instead of reading the whole struct as a single value. e.g.: `v = ptr.f["a"]()` has the same effect as `v = obj.a` if ptr points to obj.  Also, users can add to a typed pointer as they do in c/c++.

This PR also adds intrinsic functions: `sizeof[T]()` and `get_field_ptr["fieldname",T](p)`

```vb
dim a as int =32
dim a2 as int
dim b as int[] = [1,2,3,4]
dim c as mystruct

dim pa = mkref[int](addressof(a))
assert(pa.get()==32, {@line_pos()@})

pa.set(64)
assert(a==64, {@line_pos()@})
assert(pa==mkref[int](addressof(a)), {@line_pos()@})
pa=mkref[int](addressof(a2))
assert(pa==mkref[int](addressof(a2)), {@line_pos()@})

pa = mkref[int](addressof(b[0]))
assert(pa.get()==1, {@line_pos()@})
pa = pa + 1
assert(pa.get()==2, {@line_pos()@})

c.a=1
c.b=2
c.c="sadas"
dim pc = mkref[mystruct](addressof(c))
assert(pc.f["a"]()==1, {@line_pos()@})
assert(pc.fptr["b"]().get()==2, {@line_pos()@})
assert(pc.f["c"]()=="sadas", {@line_pos()@})
``` 