### PR TITLE
implement assert || print message of uncaught runtime error

### DIFF
--- a/Birdee/Birdee.vcxproj
+++ b/Birdee/Birdee.vcxproj
@@ -292,6 +292,7 @@
     <Text Include="llvm.txt" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\BirdeeHome\pylib\bdassert.py" />
     <None Include="..\BirdeeHome\pylib\bbuild.py" />
     <None Include="..\BirdeeHome\pylib\getset.py" />
     <None Include="..\BirdeeHome\pylib\traits.py" />

--- a/Birdee/Birdee.vcxproj.filters
+++ b/Birdee/Birdee.vcxproj.filters
@@ -174,5 +174,8 @@
     <None Include="..\BirdeeHome\src\typedptr.bdm">
       <Filter>资源文件\blib</Filter>
     </None>
+    <None Include="..\BirdeeHome\pylib\bdassert.py">
+      <Filter>资源文件\pylib</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/Birdee/CodeGen.cpp
+++ b/Birdee/CodeGen.cpp
@@ -292,12 +292,11 @@ static GlobalVariable* GetOrCreateTypeInfoGlobalRaw(ClassAST* cls)
 	{
 		return itr->second;
 	}
-	string name;
-	MangleNameAndAppend(name, cls->GetUniqueName());
-	name += "0_typeinfo";
-
 	if (cls->vtabledef.empty())
 	{
+		string name;
+		MangleNameAndAppend(name, cls->GetUniqueName());
+		name += "0_typeinfo";
 		auto newv = new GlobalVariable(*module, GetTypeInfoType()->llvm_type,
 			true, GlobalVariable::LinkOnceODRLinkage, nullptr,
 			name, nullptr, GlobalValue::ThreadLocalMode::NotThreadLocal, 0, true);

--- a/Birdee/MetadataDeserializer.cpp
+++ b/Birdee/MetadataDeserializer.cpp
@@ -705,6 +705,8 @@ void ImportedModule::Init(const vector<string>& package, const string& module_na
 
 	if (package.size() == 1 && package[0] == "birdee") //if is "birdee" core package, generate "type_info" first
 		classmap.find("type_info")->second->PreGenerate();
+	for (auto cls : to_run_phase0)
+		cls->Phase0();
 	for (auto& cls : this->classmap)
 	{
 		cls.second->PreGenerate();//it is safe to call multiple times
@@ -724,9 +726,6 @@ void ImportedModule::Init(const vector<string>& package, const string& module_na
 
 	BuildGlobalVaribleFromJson(json["Variables"], *this);
 	BuildGlobalFuncFromJson(json["Functions"], *this);
-
-	for (auto cls : to_run_phase0)
-		cls->Phase0();
 	
 	{
 		auto itr = json.find("InitScripts");

--- a/Birdee/Preprocessing.cpp
+++ b/Birdee/Preprocessing.cpp
@@ -2262,6 +2262,8 @@ If usage vararg name is "", match the closest vararg
 	}
 	void IndexExprAST::Phase1(bool is_in_call)
 	{
+		if (!Expr || !Index) //if is resolved
+			return;
 		if(!Expr->resolved_type.isResolved())
 			Expr->Phase1();
 		unique_ptr<ExprAST>* member=nullptr;

--- a/BirdeeHome/pylib/bdassert.py
+++ b/BirdeeHome/pylib/bdassert.py
@@ -1,0 +1,11 @@
+from bdutils import *
+
+def bdassert(expr):
+	strpos = str(get_cur_script().pos)
+	set_stmt('''if true then
+	dim _v = {expr}
+	if ! _v then
+		throw new runtime_exception(\'\'\'Assertion failed! Position: {strpos}\'\'\')
+	end
+end
+'''.format(expr=expr,strpos=strpos))

--- a/BirdeeHome/src/birdee.txt
+++ b/BirdeeHome/src/birdee.txt
@@ -102,6 +102,12 @@ class type_info
 	end
 end
 
+class runtime_exception
+	public msg as string
+	public func __init__(m as string) => msg=m
+	@virtual public func get_message() as string => msg
+end
+
 declare function BirdeeI2S (i as int) as string
 declare function BirdeeP2S (i as pointer) as string
 declare function BirdeeD2S (i as double) as string

--- a/BirdeeRuntime/BirdeeException.cpp
+++ b/BirdeeRuntime/BirdeeException.cpp
@@ -43,6 +43,7 @@ static const uint64_t MY_EXCEPTION_CLASS = MKINT('M', 7) | MKINT('N', 6) | MKINT
 #endif
 
 extern "C" bool birdee_0type__info_0is__parent__of(BirdeeTypeInfo* parent, BirdeeTypeInfo* child);
+extern "C" BirdeeTypeInfo birdee_0runtime__exception0_typeinfo_vtable;
 
 struct EmptyExceptionStruct
 {
@@ -117,10 +118,23 @@ extern "C" {
 	}
 #endif
 
+	void DumpException(BirdeeRTTIObject* obj)
+	{
+		typedef BirdeeString* (*PTRGetMessage)(BirdeeRTTIObject*);
+		fprintf(stderr, "Uncaught exception found! %s\n", obj->type->name->arr->packed.cbuf);
+		if (birdee_0type__info_0is__parent__of(&birdee_0runtime__exception0_typeinfo_vtable, obj->type))
+		{
+			PTRGetMessage func = (PTRGetMessage)obj->type->vtable[0];
+			BirdeeString* msg = func(obj);
+			fprintf(stderr, "Message: %s\n", msg->arr->packed.cbuf);
+		}
+		fputs("Stacktrace:\n", stderr);
+		printbacktrace();
+	}
+
 	DLLEXPORT void __Birdee_Throw(BirdeeRTTIObject* obj) {
 		_Unwind_RaiseException(__Birdee_CreateException(obj));
-		fprintf(stderr, "Uncaught exception found! %s\n Stacktrace:\n", obj->type->name->arr->packed.cbuf);
-		printbacktrace();
+		DumpException(obj);
 		std::terminate();
 		return;
 	}

--- a/BirdeeRuntime/BirdeeRuntime.cpp
+++ b/BirdeeRuntime/BirdeeRuntime.cpp
@@ -68,7 +68,7 @@ void Init()
 		{
 		case GCC_EXCODE:
 			//an uncaught Birdee exception occurs, return to __Birdee_Throw
-			fputs("Uncaught libgcc exception!", stderr);
+			//fputs("Uncaught libgcc exception!", stderr);
 			return EXCEPTION_CONTINUE_EXECUTION;
 		case EXCEPTION_ACCESS_VIOLATION:
 			__Birdee_Throw((BirdeeRTTIObject*)birdee_0____create__basic__exception__no__call(0));

--- a/BirdeeRuntime/BirdeeRuntime.h
+++ b/BirdeeRuntime/BirdeeRuntime.h
@@ -34,6 +34,8 @@ struct BirdeeString
 struct BirdeeTypeInfo
 {
 	BirdeeString* name;
+	BirdeeTypeInfo* parent;
+	void* vtable[0];
 };
 
 struct BirdeeRTTIObject

--- a/CoreLibs/makefile2.mak
+++ b/CoreLibs/makefile2.mak
@@ -4,7 +4,7 @@ BLIB_DIR=$(BIRDEE_HOME)\blib
 $(BLIB_DIR):
 	cmd /c "if not exist $@ mkdir $@"
 $(BIRDEE_HOME)\blib\birdee.obj: $(BLIB_DIR) $(BIRDEE_HOME)\src\birdee.txt
-	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\birdee.txt -o $(BIRDEE_HOME)\blib\birdee.obj --corelib
+	$(BIRDEE_HOME)\bin\birdeec.exe -i $(BIRDEE_HOME)\src\birdee.txt -o $(BIRDEE_HOME)\blib\birdee.obj --corelib
 
 libs: $(BIRDEE_HOME)\blib\birdee.obj
 	python3 $(BIRDEE_HOME)/pylib/bbuild.py -i $(BIRDEE_HOME)/src -o $(BLIB_DIR) test variant list hash tuple fmt vector queue stack unsafe concurrent.threading rtti

--- a/tests/container_test.txt
+++ b/tests/container_test.txt
@@ -11,53 +11,44 @@ import queue:queue_empty_exception
 
 declare function getchar() as int
 
-@enable_rtti
-class assertion_exception
-
-end
-
 {@
+from bdassert import bdassert
 from bdutils import *
 def line_pos():
 	strpos = str(get_cur_script().pos)
 	set_ast(StringLiteralAST.new(strpos))
 @}
 
-function assert(v as boolean, msg as string)
-	if !v then
-		println("Assertion failed :" + msg)
-		throw new assertion_exception
-	end
-end
 
 function check_list[T](lst as list[T], chk as T[], pos as string)
 	dim itr = lst.front()
 	println("Checking " + pos)
-	assert(lst.size() == chk.length(), {@line_pos()@})
+	{@bdassert("lst.size() == chk.length()")@}
 	for dim i=0 till chk.length()
-		assert(itr!=lst.ends(), {@line_pos()@})
-		assert(itr.get() == chk[i], {@line_pos()@})
+		{@bdassert("itr!=lst.ends()")@}
+		{@bdassert("itr.get() == chk[i]")@}
 		itr.forward()
 	end
-	assert(itr == lst.ends(), {@line_pos()@})
+	{@bdassert("itr == lst.ends()")@}
 end
+
 
 function check_map(lst as hash_map[string,int], start as int, ends as int, pos as string)
 	dim itr = lst.front()
 	println("Checking " + pos)
-	assert(lst.size() == ends - start, {@line_pos()@})
+	{@bdassert("lst.size() == ends - start")@}
 	for dim i=start till ends
 		dim n = lst.find(int2str(i))
-		assert(n!=lst.ends(), int2str(i) + " not found: " + {@line_pos()@})
-		assert(n.getv()==i, {@line_pos()@})
+		{@bdassert("n!=lst.ends()")@}
+		{@bdassert("n.getv()==i")@}
 	end
 	dim cnt=0
 	while itr!=lst.ends()
 		cnt=cnt+1
 		itr.forward()
 	end
-	assert(cnt == ends - start, {@line_pos()@})
-	assert(itr == lst.ends(), {@line_pos()@})
+	{@bdassert("cnt == ends - start")@}
+	{@bdassert("itr == lst.ends()")@}
 end
 
 function hash_test()
@@ -80,7 +71,7 @@ function hash_test()
 
 	try
 		a.remove("30")
-		assert(false, {@line_pos()@})
+		{@bdassert("false")@}
 	catch e as hash_key_excption
 		println("Caught the exception as expected")
 	end
@@ -94,7 +85,7 @@ function hash_test()
 		end
 		a.remove(int2str(i))
 	end
-	assert(a.empty(), {@line_pos()@})
+	{@bdassert("a.empty()")@}
 
 	println("Insert again")
 	for dim i=0 till 15
@@ -104,31 +95,31 @@ function hash_test()
 
 	check_map(a,0,15,{@line_pos()@})
 	a["233"] = 12345
-	assert(a["233"] == 12345, {@line_pos()@})
+	{@bdassert('''a["233"] == 12345''')@}
 	a.clear()
-	assert(a.front() == a.ends(), {@line_pos()@})
+	{@bdassert("a.front() == a.ends()")@}
 
 
 	dim hset = new hash_set[string]
 	hset.insert("HI")
 	hset.insert("1I")
-	assert(hset["HI"], {@line_pos()@})
-	assert(!hset["I"], {@line_pos()@})
+	{@bdassert('''hset["HI"]''')@}
+	{@bdassert('''!hset["I"]''')@}
 end
 
 function list_test()
 	#test list
 	dim lst = new list[int]
 
-	assert(lst.size()==0 , {@line_pos()@})
-	assert(lst.empty(), {@line_pos()@})
+	{@bdassert("lst.size()==0 ")@}
+	{@bdassert("lst.empty()")@}
 
 	lst.insert_back(123)
 	lst.insert_back(234)
 	lst.insert_back(345)
 
 	check_list(lst,[123,234,345], {@line_pos()@})
-	assert(!lst.empty(), {@line_pos()@})
+	{@bdassert("!lst.empty()")@}
 
 	lst.remove(lst.front())
 	check_list(lst,[234,345], {@line_pos()@})
@@ -146,41 +137,41 @@ function list_test()
 	lst.insert_before(itr, 44)
 	check_list(lst,[2,44,234,32],{@line_pos()@})
 
-	assert(lst.back() == itr.next(), {@line_pos()@})
+	{@bdassert("lst.back() == itr.next()")@}
 	lst.remove(lst.back())
-	assert(lst.back() == itr, {@line_pos()@})
-	assert(lst.ends() == itr.next(), {@line_pos()@})
+	{@bdassert("lst.back() == itr")@}
+	{@bdassert("lst.ends() == itr.next()")@}
 	lst.remove(lst.back())
 end
 
 function queue_test()
 	dim q = new queue[uint]
 
-	assert(q.size()==0, {@line_pos()@})
+	{@bdassert("q.size()==0")@}
 	q.push(10)
-	assert(q.size()==1, {@line_pos()@})
+	{@bdassert("q.size()==1")@}
 	q.push(20)
 	q.push(30)
 	q.push(40)
 	q.push(50)
-	assert(q.size()==5, {@line_pos()@})
+	{@bdassert("q.size()==5")@}
 
-	assert(q.front()==10, {@line_pos()@})
+	{@bdassert("q.front()==10")@}
 	q.pop()
-	assert(q.front()==20, {@line_pos()@})
+	{@bdassert("q.front()==20")@}
 	q.pop()
-	assert(q.front()==30, {@line_pos()@})
+	{@bdassert("q.front()==30")@}
 	q.pop()
-	assert(q.front()==40, {@line_pos()@})
+	{@bdassert("q.front()==40")@}
 	q.pop()
-	assert(q.front()==50, {@line_pos()@})
+	{@bdassert("q.front()==50")@}
 	q.pop()
 
-	assert(q.size()==0, {@line_pos()@})
+	{@bdassert("q.size()==0")@}
 
 	try
 		q.pop()
-		assert(false, {@line_pos()@})
+		{@bdassert("false")@}
 	catch e as queue_empty_exception
 		println("Caught queue_empty_exception as expected")
 	end
@@ -190,30 +181,30 @@ end
 function stack_test()
 	dim s = new stack[uint]
 
-	assert(s.size()==0, {@line_pos()@})
+	{@bdassert("s.size()==0")@}
 	s.push(10)
-	assert(s.size()==1, {@line_pos()@})
+	{@bdassert("s.size()==1")@}
 	s.push(20)
 	s.push(30)
 	s.push(40)
 	s.push(50)
-	assert(s.size()==5, {@line_pos()@})
+	{@bdassert("s.size()==5")@}
 
-	assert(s.top()==50, {@line_pos()@})
+	{@bdassert("s.top()==50")@}
 	s.pop()
-	assert(s.top()==40, {@line_pos()@})
+	{@bdassert("s.top()==40")@}
 	s.pop()
-	assert(s.top()==30, {@line_pos()@})
+	{@bdassert("s.top()==30")@}
 	s.pop()
-	assert(s.top()==20, {@line_pos()@})
+	{@bdassert("s.top()==20")@}
 	s.pop()
-	assert(s.top()==10, {@line_pos()@})
-	assert(s.pop()==10, {@line_pos()@})
+	{@bdassert("s.top()==10")@}
+	{@bdassert("s.pop()==10")@}
 
-	assert(s.size()==0, {@line_pos()@})
+	{@bdassert("s.size()==0")@}
 	try
 		s.pop()
-		assert(false, {@line_pos()@})
+		{@bdassert("false")@}
 	catch e as stack_empty_exception
 		println("Caught stack_empty_exception as expected")
 	end


### PR DESCRIPTION
 * users can use `{@bdassert("some expression")@}` in birdee code to do assertions. Need to import python library "bdassert"
 * If a throw object is of the class `birdee.runtime_exception`, the object's `get_message` method will be called by the runtime if the exception is not caught.