### PR TITLE
Const decl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -276,3 +276,6 @@ __pycache__/
 
 /BirdeeHome2
 /BirdeeHome/lib
+/Birdee/DynLLVM
+/BirdeeBinding/DynLLVM/BirdeeBinding.tlog
+/BirdeeCompilerCore/DynLLVM/BirdeeCo.793F4745.tlog

--- a/Birdee/Birdee.cpp
+++ b/Birdee/Birdee.cpp
@@ -12,7 +12,7 @@ using namespace Birdee;
 extern int ParseTopLevel(bool autoimport=true);
 extern void SeralizeMetadata(std::ostream& out, bool is_empty);
 extern void ParseTopLevelImportsOnly();
-extern string GetModuleNameByArray(const vector<string>& package);
+extern string GetModuleNameByArray(const vector<string>& package, const char* delimiter = ".");
 
 //GetCurrentDir copied from http://www.codebind.com/cpp-tutorial/c-get-current-directory-linuxwindows/
 #include <stdio.h>  /* defines FILENAME_MAX */

--- a/Birdee/Birdee.vcxproj
+++ b/Birdee/Birdee.vcxproj
@@ -293,10 +293,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\BirdeeHome\pylib\bbuild.py" />
+    <None Include="..\BirdeeHome\pylib\bdconst.py" />
     <None Include="..\BirdeeHome\pylib\getset.py" />
     <None Include="..\BirdeeHome\pylib\traits.py" />
     <None Include="..\BirdeeHome\src\hash.bdm" />
     <None Include="..\BirdeeHome\src\list.bdm" />
+    <None Include="..\BirdeeHome\src\system\specific\win32\file.bdm" />
     <None Include="..\BirdeeHome\src\typedptr.bdm" />
     <None Include="..\tests\ast_write_test.py" />
     <None Include="..\tests\getset_test.py" />

--- a/Birdee/Birdee.vcxproj.filters
+++ b/Birdee/Birdee.vcxproj.filters
@@ -25,6 +25,15 @@
     <Filter Include="资源文件\blib">
       <UniqueIdentifier>{66515783-4c42-478f-b199-5a7aa3253095}</UniqueIdentifier>
     </Filter>
+    <Filter Include="资源文件\blib\system">
+      <UniqueIdentifier>{e497ca51-bea2-4fc1-b030-cbe808bc7ace}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="资源文件\blib\system\specific">
+      <UniqueIdentifier>{1a9a4afa-bf4d-497b-a6c4-4ba5983d6d4a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="资源文件\blib\system\specific\win32">
+      <UniqueIdentifier>{5483bc71-9af5-4d35-928c-0d7e75090488}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">
@@ -173,6 +182,12 @@
     </None>
     <None Include="..\BirdeeHome\src\typedptr.bdm">
       <Filter>资源文件\blib</Filter>
+    </None>
+    <None Include="..\BirdeeHome\src\system\specific\win32\file.bdm">
+      <Filter>资源文件\blib\system\specific\win32</Filter>
+    </None>
+    <None Include="..\BirdeeHome\pylib\bdconst.py">
+      <Filter>资源文件\pylib</Filter>
     </None>
   </ItemGroup>
 </Project>

--- a/Birdee/BirdeeShared.cpp
+++ b/Birdee/BirdeeShared.cpp
@@ -501,7 +501,9 @@ Token Birdee::Tokenizer::gettok() {
 	{
 		LastChar = GetChar();
 		Token ret = gettok();
-		if (ret != tok_identifier)
+		if (ret == tok_private)
+			tokenizer.IdentifierStr = "private";
+		else if (ret != tok_identifier)
 			throw TokenizerError(line, pos, "Expected an identifier after \'@\'");
 		if (!isspace(LastChar) && LastChar != '\n') //if annotation is not followed by a " ", parse until the end of the line
 		{

--- a/Birdee/MetadataDeserializer.cpp
+++ b/Birdee/MetadataDeserializer.cpp
@@ -28,6 +28,7 @@ extern std::unique_ptr<FunctionAST> ParseFunction(ClassAST*);
 extern void ParseClassInPlace(ClassAST* ret, bool is_struct);
 
 extern std::vector<std::string> Birdee::source_paths;
+extern void Birdee_Register_Module(const string& name, void* globals);
 
 /*
 fix-me: Load template class & functions & instances
@@ -618,7 +619,7 @@ void BuildOrphanClassFromJson(const json& cls, ImportedModule& mod)
 	}
 }
 
-extern string GetModuleNameByArray(const vector<string>& package);
+extern string GetModuleNameByArray(const vector<string>& package, const char* delimiter = ".");
 
 string GetModuleFile(const vector<string>& package, std::ifstream& f)
 {
@@ -675,6 +676,7 @@ namespace Birdee
 {
 	extern void PushPyScope(ImportedModule* mod);
 	extern void PopPyScope();
+	extern void GetPyScope(void*& globals, void*& locals);
 }
 void ImportedModule::Init(const vector<string>& package, const string& module_name)
 {
@@ -759,6 +761,9 @@ void ImportedModule::Init(const vector<string>& package, const string& module_na
 			{
 				tmp.Phase1();
 			}
+			void* locals, *globals;
+			GetPyScope(globals, locals);
+			Birdee_Register_Module(GetModuleNameByArray(package, "_0"), globals);
 			Birdee::PopPyScope();
 		}
 	}

--- a/Birdee/MetadataDeserializer.cpp
+++ b/Birdee/MetadataDeserializer.cpp
@@ -178,6 +178,11 @@ unique_ptr<FunctionAST> BuildFunctionFromJson(const json& func, ClassAST* cls)
 	auto proto = make_unique<PrototypeAST>(name, std::move(Args), ConvertIdToType(func["return"]), cls, current_module_idx, /*is_closure*/false);
 	auto protoptr = proto.get();
 	auto ret = make_unique<FunctionAST>(std::move(proto));
+	{
+		auto itr = func.find("link_name");
+		if (itr != func.end())
+			ret->link_name = itr->get<string>();
+	}
 	ret->resolved_type.type = tok_func;
 	ret->resolved_type.proto_ast = protoptr;
 	return std::move(ret);

--- a/Birdee/MetadataSerializer.cpp
+++ b/Birdee/MetadataSerializer.cpp
@@ -252,6 +252,8 @@ json BuildFunctionJson(FunctionAST* func)
 		return ret;
 	}
 	ret["name"] = func->GetName();
+	if (func->isDeclare)
+		ret["link_name"] = func->link_name.empty()? func->GetName(): func->link_name;
 	json args = json::array();
 	for (auto& arg : func->Proto->resolved_args)
 	{
@@ -308,8 +310,6 @@ json BuildGlobalFuncJson(json& func_template)
 	func_template = json::array();
 	for (auto itr : cu.funcmap)
 	{
-		if (itr.second.first->isDeclare)
-			continue;
 		if (itr.second.first->isTemplate())
 		{
 			for (auto& instance : (itr.second.first->template_param->instances))

--- a/Birdee/MetadataSerializer.cpp
+++ b/Birdee/MetadataSerializer.cpp
@@ -261,13 +261,15 @@ json BuildFunctionJson(FunctionAST* func)
 	ret["return"] = ConvertTypeToIndex(func->Proto->resolved_type);
 	return ret;
 }
-void BuildAndPushFunctionJson(json& arr, FunctionAST* func)
+json* BuildAndPushFunctionJson(json& arr, FunctionAST* func)
 {
 	json ret = BuildFunctionJson(func);
 	if (!ret.empty())
 	{
 		arr.push_back(std::move(ret));
+		return &arr.back();
 	}
+	return nullptr;
 }
 
 void BuildClassJson(json& arr)
@@ -275,7 +277,7 @@ void BuildClassJson(json& arr)
 	int idx = 0;
 	for (auto itr : Birdee::cu.classmap)
 	{
-		class_idx_map[&itr.second.get()] = idx++;
+		class_idx_map[itr.second.first] = idx++;
 	}
 	if (class_idx_map.size() > MAX_CLASS_DEF_COUNT)
 	{
@@ -284,7 +286,8 @@ void BuildClassJson(json& arr)
 	}
 	for (auto itr : Birdee::cu.classmap)
 	{
-		arr.push_back(BuildSingleClassJson(itr.second,false));
+		arr.push_back(BuildSingleClassJson(*itr.second.first,false));
+		arr.back()["is_public"] = itr.second.second;
 	}
 }
 
@@ -293,7 +296,8 @@ json BuildGlobalVaribleJson()
 	json arr = json::array();
 	for (auto itr : cu.dimmap)
 	{
-		arr.push_back(BuildVariableJson(&itr.second.get()));
+		arr.push_back(BuildVariableJson(itr.second.first));
+		arr.back()["is_public"] = itr.second.second;
 	}
 	return arr;
 }
@@ -304,24 +308,29 @@ json BuildGlobalFuncJson(json& func_template)
 	func_template = json::array();
 	for (auto itr : cu.funcmap)
 	{
-		if (itr.second.get().isDeclare)
+		if (itr.second.first->isDeclare)
 			continue;
-		if (itr.second.get().isTemplate())
+		if (itr.second.first->isTemplate())
 		{
-			for (auto& instance : (itr.second.get().template_param->instances))
+			for (auto& instance : (itr.second.first->template_param->instances))
 			{
 				BuildAndPushFunctionJson(arr,instance.second.get());
 			}
 			json template_obj;
-			auto ptr = itr.second.get().template_param.get();
+			auto ptr = itr.second.first->template_param.get();
 			template_obj["template"] = ptr->source.get();
 			if (ptr->annotation)
 				template_obj["annotations"] = ptr->annotation->anno;
-			template_obj["source_line"] = itr.second.get().Pos.line;
+			template_obj["source_line"] = itr.second.first->Pos.line;
+			template_obj["is_public"] = itr.second.second;
 			func_template.push_back(std::move(template_obj));
 		}
 		else
-			BuildAndPushFunctionJson(arr,&itr.second.get());
+		{
+			auto jsonobj = BuildAndPushFunctionJson(arr, itr.second.first);
+			if(jsonobj)
+				(*jsonobj)["is_public"] = itr.second.second;
+		}
 	}
 	return arr;
 }
@@ -409,7 +418,7 @@ void BuildExportedPrototypePlaceholders()
 {
 	for (auto& node : cu.functypemap)
 	{
-		functype_idx_map[node.second.get()] = NextFunctionTypeIndex--;
+		functype_idx_map[node.second.first.get()] = NextFunctionTypeIndex--;
 		exported_functype.push_back(json());
 	}
 	if (functype_idx_map.size() >= MAX_CLASS_DEF_COUNT)
@@ -425,7 +434,8 @@ void BuildExportedPrototypes()
 	int idx = 0;
 	for (auto& itr : cu.functypemap)
 	{
-		exported_functype[idx]=BuildPrototypeJson(itr.second.get());
+		exported_functype[idx]=BuildPrototypeJson(itr.second.first.get());
+		exported_functype[idx]["is_public"] = itr.second.second;
 		idx++;
 	}
 }

--- a/Birdee/Parser.cpp
+++ b/Birdee/Parser.cpp
@@ -1518,12 +1518,12 @@ ImportTree* Birdee::ImportTree::Insert(const vector<string>& package, int level)
 	}
 }
 
-BD_CORE_API string GetModuleNameByArray(const vector<string>& package)
+BD_CORE_API string GetModuleNameByArray(const vector<string>& package, const char* delimiter = ".")
 {
 	string ret=package[0];
 	for (int i = 1; i < package.size(); i++)
 	{
-		ret += '.';
+		ret += delimiter;
 		ret += package[i];
 	}
 	return ret;

--- a/Birdee/Preprocessing.cpp
+++ b/Birdee/Preprocessing.cpp
@@ -62,6 +62,7 @@ BD_CORE_API void* LoadBindingFunction(const char* name)
 #define BirdeeCopyPyScope_NAME "?BirdeeCopyPyScope@@YAPEAXPEAX@Z"
 #define BirdeeDerefObj_NAME "?BirdeeDerefObj@@YAXPEAX@Z"
 #define BirdeeGetOrigScope_NAME "?BirdeeGetOrigScope@@YAPEAXXZ"
+#define Birdee_Register_Module_NAME "?Birdee_Register_Module@@YAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEAX@Z"
 #else
 
 #include <dlfcn.h>
@@ -90,6 +91,7 @@ BD_CORE_API void* LoadBindingFunction(const char* name)
 #define BirdeeCopyPyScope_NAME "_Z17BirdeeCopyPyScopePv"
 #define BirdeeDerefObj_NAME "_Z14BirdeeDerefObjPv"
 #define BirdeeGetOrigScope_NAME "_Z18BirdeeGetOrigScopev"
+#define Birdee_Register_Module_NAME "_Z22Birdee_Register_ModuleRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPv"
 #endif
 
 static void Birdee_RunAnnotationsOn(std::vector<std::string>& anno, StatementAST* ths, SourcePos pos, void* globalscope)
@@ -163,6 +165,16 @@ static void* BirdeeGetOrigScope()
 	}
 	return orig_scope;
 }
+void Birdee_Register_Module(const string& name, void* globals)
+{
+	typedef void*(*PtrImpl)(const string& name, void* globals);
+	static PtrImpl impl = nullptr;
+	if (impl == nullptr)
+	{
+		impl = (PtrImpl)LoadBindingFunction(Birdee_Register_Module_NAME);
+	}
+	impl(name, globals);
+}
 #else
 extern void Birdee_RunAnnotationsOn(std::vector<std::string>& anno, StatementAST* ths, SourcePos pos, void* globalscope);
 extern void Birdee_ScriptAST_Phase1(ScriptAST* ths, void* globalscope, void* localscope);
@@ -170,6 +182,7 @@ extern void Birdee_ScriptType_Resolve(ResolvedType* out, ScriptType* ths, Source
 extern void* BirdeeCopyPyScope(void* src);
 extern void BirdeeDerefObj(void* obj);
 extern void* BirdeeGetOrigScope();
+extern void Birdee_Register_Module(const string& name, void* globals);
 #endif
 
 #define CompileAssert(a, p ,msg)\
@@ -1015,7 +1028,7 @@ Token PromoteNumberExpression(unique_ptr<ExprAST>& v1, unique_ptr<ExprAST>& v2,b
 
 }
 
-extern string GetModuleNameByArray(const vector<string>& package);
+extern string GetModuleNameByArray(const vector<string>& package, const char* delimiter = ".");
 
 namespace Birdee
 {

--- a/Birdee/PythonBinding2.cpp
+++ b/Birdee/PythonBinding2.cpp
@@ -132,6 +132,15 @@ BIRDEE_BINDING_API void* BirdeeGetOrigScope()
 	return InitPython().orig_scope.ptr();
 }
 
+BIRDEE_BINDING_API void Birdee_Register_Module(const string& name, void* globals)
+{
+	py::module m(name.c_str());
+	m.attr("__dict__").attr("update")(py::cast<py::object>((PyObject*)globals));
+	py::str pyname = py::str(name);
+	m.attr("__name__") = pyname;
+	py::module::import("sys").attr("modules").attr("__setitem__")(pyname, m);
+}
+
 BIRDEE_BINDING_API void Birdee_ScriptAST_Phase1(ScriptAST* ths, void* globals, void* locals)
 {
 	cur_script_ast = ths;

--- a/Birdee/PythonBinding2.cpp
+++ b/Birdee/PythonBinding2.cpp
@@ -437,7 +437,7 @@ void RegisiterClassForBinding(py::module& m)
 		if (itr == cu.funcmap.end())
 			return GetRef((FunctionAST*)nullptr);
 		else
-			return itr->second;
+			return GetRef(itr->second.first);
 	});
 	m.def("get_top_level", []() {return GetRef(cu.toplevel); });
 	m.def("get_compile_error", []() {return GetRef(CompileError::last_error); });

--- a/Birdee/include/BdAST.h
+++ b/Birdee/include/BdAST.h
@@ -93,13 +93,14 @@ namespace Birdee {
 	BD_CORE_API extern string GetTokenString(Token tok);
 
 	class AnnotationStatementAST;
-
+	
 	struct ImportedModule
 	{
-		unordered_map<string, unique_ptr<ClassAST>> classmap;
-		unordered_map<string, unique_ptr<FunctionAST>> funcmap;
-		unordered_map<string, unique_ptr<VariableSingleDefAST>> dimmap;
-		unordered_map<string, unique_ptr<PrototypeAST>> functypemap;
+		//mapping from name to <Symbol,is_public>
+		unordered_map<string, std::pair<unique_ptr<ClassAST>,bool>> classmap;
+		unordered_map<string, std::pair<unique_ptr<FunctionAST>, bool>> funcmap;
+		unordered_map<string, std::pair<unique_ptr<VariableSingleDefAST>, bool>> dimmap;
+		unordered_map<string, std::pair<unique_ptr<PrototypeAST>, bool>> functypemap;
 
 		unordered_map<std::reference_wrapper<const string>, ClassAST*> imported_classmap;
 		unordered_map<std::reference_wrapper<const string>, FunctionAST*> imported_funcmap;
@@ -342,10 +343,11 @@ namespace Birdee {
 
 		vector<string> search_path; //the search paths, with "/" at the end
 		vector<unique_ptr<StatementAST>> toplevel;
-		unordered_map<std::reference_wrapper<const string>, std::reference_wrapper<ClassAST>> classmap;
-		unordered_map<std::reference_wrapper<const string>, std::reference_wrapper<FunctionAST>> funcmap;
-		unordered_map<std::reference_wrapper<const string>, std::reference_wrapper<VariableSingleDefAST>> dimmap;
-		unordered_map<std::reference_wrapper<const string>, unique_ptr<PrototypeAST>> functypemap;
+		//name to <symbol, is_public> mapping
+		unordered_map<std::reference_wrapper<const string>, std::pair<ClassAST*,bool>> classmap;
+		unordered_map<std::reference_wrapper<const string>, std::pair<FunctionAST*,bool>> funcmap;
+		unordered_map<std::reference_wrapper<const string>, std::pair<VariableSingleDefAST*,bool>> dimmap;
+		unordered_map<std::reference_wrapper<const string>, std::pair<unique_ptr<PrototypeAST>,bool>> functypemap;
 
 		//maps from short names ("import a.b:c" => "c") to the imported AST
 		unordered_map<std::reference_wrapper<const string>, ClassAST*> imported_classmap;

--- a/BirdeeHome/pylib/bdconst.py
+++ b/BirdeeHome/pylib/bdconst.py
@@ -1,0 +1,11 @@
+from bdutils import *
+import inspect
+
+def const_uint(i):
+	assert( isinstance(i,int))
+	return lambda:set_uint(i)
+
+def define(name, value):
+	glb = inspect.stack()[1][0].f_globals
+	glb["_"+name] = value
+	glb[name] = const_uint(value)

--- a/BirdeeHome/src/birdee.txt
+++ b/BirdeeHome/src/birdee.txt
@@ -68,9 +68,7 @@ class string
 		len=length
 		buf=new byte * (length+1)
 		buf[length]=0
-		for dim i as uint=0 till length
-			buf[i] = buffer[i]
-		end
+		memcpy(addressof(buf[0]),addressof(buffer[start]),length,1,false)
 	end
 
 	public function get_bytes() as byte[]

--- a/BirdeeHome/src/birdee.txt
+++ b/BirdeeHome/src/birdee.txt
@@ -145,6 +145,7 @@ class div_zero_exception
 
 end
 
+@private
 function __create_basic_exception_no_call(ty as int) as pointer
 	if ty==0 then
 		return pointerof(new mem_access_exception)

--- a/BirdeeHome/src/birdee.txt
+++ b/BirdeeHome/src/birdee.txt
@@ -1,12 +1,9 @@
-declare function puts (str as pointer) as int
-declare function prints (str as pointer) as int
-declare function memcpy alias "llvm.memcpy.p0i8.p0i8.i32"(dest as pointer,src as pointer, len as uint, align as uint, is_volatile as boolean)
-declare function strcmp (a as pointer,b as pointer) as int
-declare function trap alias "llvm.debugtrap" ()
+@private declare function puts (str as pointer) as int
+@private declare function prints (str as pointer) as int
+@private declare function memcpy alias "llvm.memcpy.p0i8.p0i8.i32"(dest as pointer,src as pointer, len as uint, align as uint, is_volatile as boolean)
+@private declare function strcmp (a as pointer,b as pointer) as int
+declare function breakpoint alias "llvm.debugtrap" ()
 
-function breakpoint()
-	trap()
-end
 
 class genericarray
 	private len as uint
@@ -102,13 +99,9 @@ class type_info
 	end
 end
 
-declare function BirdeeI2S (i as int) as string
-declare function BirdeeP2S (i as pointer) as string
-declare function BirdeeD2S (i as double) as string
-
-function int2str(i as int) as string
-	return BirdeeI2S(i)
-end
+declare function int2str alias "BirdeeI2S" (i as int) as string
+declare function pointer2str alias "BirdeeP2S" (i as pointer) as string
+declare function double2str alias "BirdeeD2S" (i as double) as string
 
 function bool2str(i as boolean) as string
 	if i then
@@ -116,14 +109,6 @@ function bool2str(i as boolean) as string
 	else
 		return "false"
 	end
-end
-
-function pointer2str(i as pointer) as string
-	return BirdeeP2S(i)
-end
-
-function double2str(i as double) as string
-	return BirdeeD2S(i)
 end
 
 function print(str as string)

--- a/BirdeeHome/src/system/specific/win32/file.bdm
+++ b/BirdeeHome/src/system/specific/win32/file.bdm
@@ -1,0 +1,103 @@
+package system.specific.win32
+
+@init_script
+{@
+from bdconst import *
+
+define("DELETE",                           0x00010000)
+define("READ_CONTROL",                     0x00020000)
+define("WRITE_DAC",                        0x00040000)
+define("WRITE_OWNER",                      0x00080000)
+define("SYNCHRONIZE",                      0x00100000)
+
+define("STANDARD_RIGHTS_REQUIRED",         0x000F0000)
+
+define("STANDARD_RIGHTS_READ",             _READ_CONTROL)
+define("STANDARD_RIGHTS_WRITE",            _READ_CONTROL)
+define("STANDARD_RIGHTS_EXECUTE",          _READ_CONTROL)
+
+define("STANDARD_RIGHTS_ALL",              0x001F0000)
+
+define("SPECIFIC_RIGHTS_ALL",              0x0000FFFF)
+
+define("GENERIC_READ",                     0x80000000)
+define("GENERIC_WRITE",                    0x40000000)
+define("GENERIC_EXECUTE",                  0x20000000)
+define("GENERIC_ALL",                      0x10000000)
+
+define("FILE_READ_DATA",             0x0001 )    # file & pipe
+define("FILE_LIST_DIRECTORY",        0x0001 )    # directory
+
+define("FILE_WRITE_DATA",            0x0002 )    # file & pipe
+define("FILE_ADD_FILE",              0x0002 )    # directory
+
+define("FILE_APPEND_DATA",           0x0004 )    # file
+define("FILE_ADD_SUBDIRECTORY",      0x0004 )    # directory
+define("FILE_CREATE_PIPE_INSTANCE",  0x0004 )    # named pipe
+
+define("FILE_READ_EA",               0x0008 )    # file & directory
+define("FILE_WRITE_EA",              0x0010 )    # file & directory
+define("FILE_EXECUTE",               0x0020 )    # file
+define("FILE_TRAVERSE",              0x0020 )    # directory
+define("FILE_DELETE_CHILD",          0x0040 )    # directory
+define("FILE_READ_ATTRIBUTES",       0x0080 )    # all
+define("FILE_WRITE_ATTRIBUTES",      0x0100 )    # all
+
+define("FILE_ALL_ACCESS", _STANDARD_RIGHTS_REQUIRED | _SYNCHRONIZE | 0x1FF)
+
+define("FILE_GENERIC_READ",_STANDARD_RIGHTS_READ| _FILE_READ_DATA|_FILE_READ_ATTRIBUTES|_FILE_READ_EA|_SYNCHRONIZE)
+
+
+define("FILE_GENERIC_WRITE",        _STANDARD_RIGHTS_WRITE    |\
+                                   _FILE_WRITE_DATA          |\
+                                   _FILE_WRITE_ATTRIBUTES    |\
+                                   _FILE_WRITE_EA            |\
+                                   _FILE_APPEND_DATA         |\
+                                   _SYNCHRONIZE)
+
+
+define("FILE_GENERIC_EXECUTE",      _STANDARD_RIGHTS_EXECUTE  |\
+                                   _FILE_READ_ATTRIBUTES     |\
+                                   _FILE_EXECUTE             |\
+                                   _SYNCHRONIZE)
+
+define("CREATE_NEW",1)
+define("CREATE_ALWAYS",2)
+define("OPEN_EXISTING",3)
+define("OPEN_ALWAYS",4)
+define("TRUNCATE_EXISTING",5)
+
+# end_access
+define("FILE_SHARE_READ",                 0x00000001)
+define("FILE_SHARE_WRITE",                0x00000002) 
+define("FILE_SHARE_DELETE",               0x00000004)
+
+define("FILE_SHARE_READ",                 0x00000001)  
+define("FILE_SHARE_WRITE",                0x00000002)  
+define("FILE_SHARE_DELETE",               0x00000004)  
+define("FILE_ATTRIBUTE_READONLY",             0x00000001)  
+define("FILE_ATTRIBUTE_HIDDEN",               0x00000002)  
+define("FILE_ATTRIBUTE_SYSTEM",               0x00000004)  
+define("FILE_ATTRIBUTE_DIRECTORY",            0x00000010)  
+define("FILE_ATTRIBUTE_ARCHIVE",              0x00000020)  
+define("FILE_ATTRIBUTE_DEVICE",               0x00000040)  
+define("FILE_ATTRIBUTE_NORMAL",               0x00000080)  
+define("FILE_ATTRIBUTE_TEMPORARY",            0x00000100)  
+define("FILE_ATTRIBUTE_SPARSE_FILE",          0x00000200)  
+define("FILE_ATTRIBUTE_REPARSE_POINT",        0x00000400)  
+define("FILE_ATTRIBUTE_COMPRESSED",           0x00000800)  
+define("FILE_ATTRIBUTE_OFFLINE",              0x00001000)  
+define("FILE_ATTRIBUTE_NOT_CONTENT_INDEXED",  0x00002000)  
+define("FILE_ATTRIBUTE_ENCRYPTED",            0x00004000)  
+define("FILE_ATTRIBUTE_INTEGRITY_STREAM",     0x00008000)  
+define("FILE_ATTRIBUTE_VIRTUAL",              0x00010000)  
+define("FILE_ATTRIBUTE_NO_SCRUB_DATA",        0x00020000)  
+define("FILE_ATTRIBUTE_EA",                   0x00040000)  
+define("FILE_ATTRIBUTE_PINNED",               0x00080000)  
+define("FILE_ATTRIBUTE_UNPINNED",             0x00100000)  
+define("FILE_ATTRIBUTE_RECALL_ON_OPEN",       0x00040000)  
+define("FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS", 0x00400000) 
+@}
+
+declare function CreateFileA(lpFileName as pointer, dwDesiredAccess as uint,dwShareMode as uint, lpSecurityAttributes as pointer##LPSECURITY_ATTRIBUTES##, dwCreationDisposition as uint, dwFlagsAndAttributes as uint, hTemplateFile as pointer) as pointer
+declare function ReadFile(hFile as pointer, lpBuffer as pointer, nNumberOfBytesToRead as uint, lpNumberOfBytesRead as pointer ##uint##, lpOverlapped as pointer ##LPOVERLAPPED##) as int

--- a/BirdeePlayground/BirdeePlayground.cpp
+++ b/BirdeePlayground/BirdeePlayground.cpp
@@ -99,7 +99,7 @@ int main()
 		std::cerr << "Cannot import function fmt.printany\n";
 		std::exit(2);
 	}
-	auto printany_func = printany_func_itr->second.get();
+	auto printany_func = printany_func_itr->second.first.get();
 
 	std::unique_ptr < llvm::orc::KaleidoscopeJIT> TheJIT = make_unique<llvm::orc::KaleidoscopeJIT>();
 #ifdef _WIN32

--- a/BirdeePlayground/Makefile
+++ b/BirdeePlayground/Makefile
@@ -1,7 +1,7 @@
 all: $(BIN_DIR)/birdeeplay
 
 $(BIN_DIR)/birdeeplay: BirdeePlayground.o
-	$(CXX) -o $@ $(CPPFLAGS)  -L$(LIB_DIR) -Wl,--export-dynamic -Wl,--start-group BirdeePlayground.o $(BLIB_DIR)/../blib/birdee.o $(BLIB_DIR)/../blib/hash_map.o $(BLIB_DIR)/../blib/concurrent/threading.o $(BLIB_DIR)/../blib/string_buffer.o -lBirdeeCompilerCore -lBirdeeRuntime -lLLVM-6.0 -ldl -lpthread -lgc -Wl,--end-group -Wl,-rpath='$$ORIGIN/../lib/'
+	$(CXX) -o $@ $(CPPFLAGS)  -L$(LIB_DIR) -Wl,--export-dynamic -Wl,--start-group BirdeePlayground.o $(BLIB_DIR)/../blib/birdee.o $(BLIB_DIR)/../blib/hash.o $(BLIB_DIR)/../blib/concurrent/threading.o $(BLIB_DIR)/../blib/string_buffer.o -lBirdeeCompilerCore -lBirdeeRuntime -lLLVM-6.0 -ldl -lpthread -lgc -Wl,--end-group -Wl,-rpath='$$ORIGIN/../lib/'
 .PHONY:clean remake
 
 

--- a/CoreLibs/makefile2.mak
+++ b/CoreLibs/makefile2.mak
@@ -4,10 +4,10 @@ BLIB_DIR=$(BIRDEE_HOME)\blib
 $(BLIB_DIR):
 	cmd /c "if not exist $@ mkdir $@"
 $(BIRDEE_HOME)\blib\birdee.obj: $(BLIB_DIR) $(BIRDEE_HOME)\src\birdee.txt
-	..\x64\Debug\birdeec.exe -i $(BIRDEE_HOME)\src\birdee.txt -o $(BIRDEE_HOME)\blib\birdee.obj --corelib
+	$(BIRDEE_HOME)\bin\birdeec.exe -i $(BIRDEE_HOME)\src\birdee.txt -o $(BIRDEE_HOME)\blib\birdee.obj --corelib
 
 libs: $(BIRDEE_HOME)\blib\birdee.obj
-	python3 $(BIRDEE_HOME)/pylib/bbuild.py -i $(BIRDEE_HOME)/src -o $(BLIB_DIR) test variant list hash tuple fmt vector queue stack unsafe concurrent.threading rtti
+	python3 $(BIRDEE_HOME)/pylib/bbuild.py -i $(BIRDEE_HOME)/src -o $(BLIB_DIR) variant list hash tuple fmt vector queue stack unsafe concurrent.threading rtti system.specific.win32.file
 
 clean:
 	del $(BLIB_DIR)\*.obj

--- a/tests/os_specific/win32_file.txt
+++ b/tests/os_specific/win32_file.txt
@@ -1,0 +1,13 @@
+package os_specific
+
+import system.specific.win32.file:*
+
+{@from system_0specific_0win32_0file import *@}
+dim hFile = CreateFileA("d:\\temp.txt".get_raw(),{@GENERIC_READ()@},{@FILE_SHARE_READ()@},pointerof(null),{@OPEN_EXISTING()@},{@FILE_ATTRIBUTE_NORMAL()@},pointerof(null))
+
+dim buf  = new byte *100
+dim bytesRead as uint
+ReadFile(hFile, addressof(buf[0]), 99, addressof(bytesRead), pointerof(null))
+dim str = new string:copy_bytes(buf,0,bytesRead)
+println(str)
+println("done, bytes" + int2str(bytesRead))

--- a/tests/py_module_test/a.txt
+++ b/tests/py_module_test/a.txt
@@ -1,0 +1,8 @@
+package py_module_test
+
+@init_script
+{@
+a=1
+def p():
+	print(a)
+@}

--- a/tests/py_module_test/b.txt
+++ b/tests/py_module_test/b.txt
@@ -1,0 +1,8 @@
+package py_module_test
+
+import py_module_test.a
+
+{@
+from py_module_test_0a import p
+p()
+@}

--- a/tests/scripttest.py
+++ b/tests/scripttest.py
@@ -42,6 +42,15 @@ set_print_ir(False)
 
 print("The OS name is ", get_os_name(), ". The target bit width is ", get_target_bits())
 
+
+assert_fail('''
+__create_basic_exception_no_call(1)
+''')
+
+assert_fail('''
+birdee.__create_basic_exception_no_call(1)
+''')
+
 assert_generate_ok('''
 func get() as int => 3
 dim a as int[] = [1,2,get()]
@@ -254,7 +263,7 @@ assert_fail('''
 	''')
 
 assert_fail('''
-import hash_map:hash_map
+import hash:hash_map
 
 dim map = new hash_map
 	''')

--- a/tests/scripttest.py
+++ b/tests/scripttest.py
@@ -42,6 +42,11 @@ set_print_ir(False)
 
 print("The OS name is ", get_os_name(), ". The target bit width is ", get_target_bits())
 
+assert_generate_ok('''
+dim a=int2str(1)+pointer2str(pointerof(null))+double2str(3.0)
+a.get_raw()
+breakpoint()
+''')
 
 assert_fail('''
 __create_basic_exception_no_call(1)


### PR DESCRIPTION
 * Enable private module symbols: add and `@private` before declare/dim/function/class/functype/closure of the toplevel code, the symbol will be hidden from other modules
 * Other modules can use the function declarations of a module
 * Other module's python code can import the "init script" of any Birdee module as a Python module
 * Add Python lib for generating constants
 * Add basic APIs for win32 files