### PR TITLE
use linker name aliasing instead of using -e switch

### DIFF
--- a/BirdeeHome/pylib/bbuild.py
+++ b/BirdeeHome/pylib/bbuild.py
@@ -7,6 +7,7 @@ from threading import Thread
 from threading import Lock
 import locale
 import traceback
+import mangler 
 #run %comspec% /k "D:\ProgramFiles\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat" first!!
 
 source_dirs=[]
@@ -98,6 +99,9 @@ class compile_unit:
 
 	def add_reverse_dependency(self,cu):
 		self.reverse_dependency.add(cu)
+
+	def get_top_level_func_name(self):
+		return mangler.mangle_func(".".join(modu)+"_1main")
 
 	#decrease dependency_cnt by 1, return true when this cu is ready to compile
 	def dependency_done(self):
@@ -278,8 +282,8 @@ def compile_module(modu,src,is_main):
 		cmdarr.append(bpath)
 	cmdarr.append("-l")
 	cmdarr.append(outpath)
-	if is_main:
-		cmdarr.append("-e")
+	#if is_main:
+	#	cmdarr.append("-e")
 	print("Running command " + " ".join(cmdarr))
 	ret=subprocess.run(cmdarr)
 	if ret.returncode!=0:
@@ -306,6 +310,9 @@ def link_msvc():
 		lpath += obj_postfix
 		obj_files += ' "{lpath}"'.format(lpath=lpath)
 	cmd=msvc_command.format(linker_path,link_target,pdb_path,link_cmd,obj_files,link_target+".manifest")
+	if link_executable:
+		alias_cmd = "/alternatename:main=" + mangler.mangle_func('.'.join(root_modules[0])) + "_0_1main"
+		cmd += alias_cmd
 	print("Running command " + cmd)
 	ret=subprocess.run(cmd)
 	if ret.returncode!=0:
@@ -325,6 +332,9 @@ def link_gcc():
 	cmdarr.append("-Wl,--end-group")
 	if len(link_cmd):
 		cmdarr.append(link_cmd)
+	if link_executable:
+		alias_cmd = "-Wl,--defsym,main=" + mangler.mangle_func('.'.join(root_modules[0])) + "_0_1main"
+		cmdarr.append(alias_cmd)
 	print("Running command " + ' '.join(cmdarr))
 	ret=subprocess.run(cmdarr)
 	if ret.returncode!=0:

--- a/BirdeeHome/pylib/mangler.py
+++ b/BirdeeHome/pylib/mangler.py
@@ -1,0 +1,20 @@
+def mangle_func(name):
+	out=''
+	for s in name:
+		if s == '_':
+			out += '__'
+		elif s == '.':
+			out += '_0'
+		elif s == '[':
+			out += '_2'
+		elif s == ']':
+			out += '_3'
+		elif s == ',':
+			out += '_4'
+		elif s == ' ':
+			out += '_5'
+		elif s.isalnum(): #is number of [a-z][A-Z]
+			out += s
+		else:
+			out += '_x%0.2X' % ord(s)
+	return out


### PR DESCRIPTION
Old way to link the main function is using -e switch in birdeec to rename module_0name_0_1main to main, but this results in the failure to link the module as a non-main module when other modules import this module.
We now use name aliasing in linker for gcc and msvc to rename the top-level at link time