### PR TITLE
Many fixes and features

### DIFF
--- a/Birdee/Birdee.cpp
+++ b/Birdee/Birdee.cpp
@@ -34,11 +34,11 @@ std::string GetCurrentWorkingDir(void) {
 
 
 #ifdef _WIN32
-extern void RunGenerativeScript();
+extern int RunGenerativeScript();
 #else
 #include <dlfcn.h>
 extern void* LoadBindingFunction(const char* name);
-	static void RunGenerativeScript()
+	static int RunGenerativeScript()
 	{
 		typedef void(*PtrImpl)();
 		static PtrImpl impl = nullptr;
@@ -244,8 +244,7 @@ int main(int argc,char** argv)
 
 	if (cu.is_script_mode)
 	{
-		RunGenerativeScript();
-		return 0;
+		return RunGenerativeScript();
 	}
 	int is_empty = false;
 	try {

--- a/Birdee/Birdee.vcxproj
+++ b/Birdee/Birdee.vcxproj
@@ -257,6 +257,7 @@
     <ClInclude Include="include\TokenDef.h" />
     <ClInclude Include="include\Tokenizer.h" />
     <ClInclude Include="include\Util.h" />
+    <ClInclude Include="resource.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
   </ItemGroup>
@@ -306,6 +307,7 @@
     <None Include="..\BirdeeHome\src\typedptr.bdm" />
     <None Include="..\tests\ast_write_test.py" />
     <None Include="..\tests\getset_test.py" />
+    <None Include="..\tests\makefile2.mak" />
     <None Include="..\tests\scripttest.py" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Birdee/Birdee.vcxproj
+++ b/Birdee/Birdee.vcxproj
@@ -287,7 +287,6 @@
     <Text Include="..\BirdeeHome\src\tuple.txt" />
     <Text Include="..\tests\exception_test.txt" />
     <Text Include="..\tests\hardware_exception_test.txt" />
-    <Text Include="..\tests\hash_map_test.txt" />
     <Text Include="..\tests\logic_obj_cmp.txt" />
     <Text Include="..\tests\operators.txt" />
     <Text Include="..\tests\template_vararg.py" />

--- a/Birdee/Birdee.vcxproj.filters
+++ b/Birdee/Birdee.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClInclude Include="include\CompilerOptions.h">
       <Filter>头文件</Filter>
     </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>头文件</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -206,6 +209,9 @@
     </None>
     <None Include="..\BirdeeHome\src\system\specific\unistd\file.bdm">
       <Filter>资源文件\blib\system\specific\unistd</Filter>
+    </None>
+    <None Include="..\tests\makefile2.mak">
+      <Filter>资源文件</Filter>
     </None>
   </ItemGroup>
 </Project>

--- a/Birdee/Birdee.vcxproj.filters
+++ b/Birdee/Birdee.vcxproj.filters
@@ -115,9 +115,6 @@
     <Text Include="..\BirdeeHome\src\template_test.txt">
       <Filter>资源文件\template</Filter>
     </Text>
-    <Text Include="..\tests\hash_map_test.txt">
-      <Filter>资源文件\tests</Filter>
-    </Text>
     <Text Include="..\tests\logic_obj_cmp.txt">
       <Filter>资源文件\tests</Filter>
     </Text>

--- a/Birdee/CodeGen.cpp
+++ b/Birdee/CodeGen.cpp
@@ -505,8 +505,8 @@ void GenerateType(const Birdee::ResolvedType& type, PDIType& dtype, llvm::Type* 
 		break;
 	case tok_func:
 	{
-		auto functy = type.proto_ast->GenerateFunctionType(true)->getPointerTo();
-		auto funcdty = type.proto_ast->GenerateDebugType(true);
+		auto functy = type.proto_ast->GenerateFunctionType()->getPointerTo();
+		auto funcdty = type.proto_ast->GenerateDebugType();
 		if (!type.proto_ast->is_closure)
 		{
 			base = functy;
@@ -607,7 +607,6 @@ void Birdee::VariableSingleDefAST::PreGenerateForGlobal()
 			dinfo.cu, var_name, var_name, dinfo.cu->getFile(), Pos.line, ty,
 			true);
 	llvm_value = v;
-	
 	v->addDebugInfo(D); 
 }
 

--- a/Birdee/MetadataDeserializer.cpp
+++ b/Birdee/MetadataDeserializer.cpp
@@ -475,8 +475,9 @@ void PreBuildOrphanClassFromJson(const json& cls, ImportedModule& mod)
 					  //if no instance, add a placeholder to the instance set
 						auto newclass = make_unique<ClassAST>(string(), SourcePos(source_paths.size() - 1, 0, 0)); //placeholder
 						classdef = newclass.get();
+						auto& vec = *pargs;
 						classdef->template_instance_args = std::move(pargs);
-						src->template_param->AddImpl(*pargs, std::move(newclass));
+						src->template_param->AddImpl(vec, std::move(newclass));
 					}
 				}
 				else

--- a/Birdee/MetadataSerializer.cpp
+++ b/Birdee/MetadataSerializer.cpp
@@ -252,7 +252,7 @@ json BuildFunctionJson(FunctionAST* func)
 		return ret;
 	}
 	ret["name"] = func->GetName();
-	if (func->isDeclare)
+	if (!func->Proto->cls && func->isDeclare)
 		ret["link_name"] = func->link_name.empty()? func->GetName(): func->link_name;
 	json args = json::array();
 	for (auto& arg : func->Proto->resolved_args)

--- a/Birdee/Parser.cpp
+++ b/Birdee/Parser.cpp
@@ -1790,7 +1790,7 @@ void ImportedModule::HandleImport()
 	}
 }
 
-void ParseImports(bool need_do_import)
+BD_CORE_API void ParseImports(bool need_do_import)
 {
 	for (;;)
 	{

--- a/Birdee/Parser.cpp
+++ b/Birdee/Parser.cpp
@@ -538,6 +538,8 @@ std::unique_ptr<ExprAST> ParsePrimaryExpression()
 	{
 		anno.push_back(tokenizer.IdentifierStr);
 		tokenizer.GetNextToken();
+		while (tokenizer.CurTok == tok_newline)
+			tokenizer.GetNextToken();
 	}
 	auto push_expr = [&anno, &firstexpr](std::unique_ptr<ExprAST>&& st)
 	{

--- a/Birdee/Preprocessing.cpp
+++ b/Birdee/Preprocessing.cpp
@@ -2192,6 +2192,7 @@ If usage vararg name is "", match the closest vararg
 		cls->template_source_class = src_cls;
 		cls->name += GetTemplateArgumentString(args);
 		scope_mgr.SetClassTemplateEnv(args, parameters, mod, pos);
+		scope_mgr.py_scope_dicts.push_back(ScopeManager::PyScope(mod));
 		scope_mgr.template_trace_back_stack.push_back(std::make_pair(&scope_mgr.template_class_stack, scope_mgr.template_class_stack.size() - 1));
 		for (auto& funcdef : cls->funcs)
 		{
@@ -2200,6 +2201,7 @@ If usage vararg name is "", match the closest vararg
 		cls->Phase0();
 		cls->Phase1();
 		scope_mgr.template_trace_back_stack.pop_back();
+		scope_mgr.py_scope_dicts.pop_back();
 		scope_mgr.RestoreClassTemplateEnv();
 	}
 

--- a/Birdee/Preprocessing.cpp
+++ b/Birdee/Preprocessing.cpp
@@ -1758,7 +1758,7 @@ namespace Birdee
 			//if is not a template, fall through to the following code
 		}
 		impl->Phase1();
-		Birdee_RunAnnotationsOn(anno,this,impl->Pos, globals);
+		Birdee_RunAnnotationsOn(anno,impl.get(),impl->Pos, globals);
 		if (is_expr)
 		{
 			resolved_type = static_cast<ExprAST*>(impl.get())->resolved_type;

--- a/Birdee/Preprocessing.cpp
+++ b/Birdee/Preprocessing.cpp
@@ -2936,6 +2936,8 @@ If usage vararg name is "", match the closest vararg
 		{
 			func = e.src_template;
 			assert(func->isTemplate());
+			CompileAssert(func->is_vararg || e.args->size() <= func->template_param->params.size(), Pos,
+				"Too many template arguments are given");
 			for (int i = 0; i < e.args->size(); i++)
 			{
 				ValidateOneTemplateArg(*e.args, func->template_param->params, Pos, i);

--- a/Birdee/Preprocessing.cpp
+++ b/Birdee/Preprocessing.cpp
@@ -1620,7 +1620,7 @@ namespace Birdee
 	{
 		const PrototypeAST* proto = this;
 		size_t v = proto->resolved_type.rawhash() << 3; //return type
-		v ^= (uintptr_t)proto->cls; //belonging class
+		//v ^= (uintptr_t)proto->cls; //belonging class
 		v ^= proto->is_closure;
 		int offset = 6;
 		for (auto& arg : proto->resolved_args) //argument types
@@ -1635,8 +1635,8 @@ namespace Birdee
 	{
 		if (ths.is_closure != other.is_closure) //if is_closure field is not the same
 			return false;
-		if (ths.cls != other.cls)
-			return false;
+		//if (ths.cls != other.cls)
+		//	return false;
 		return ths.IsSamePrototype(other);
 	}
 	bool ResolvedType::operator<(const ResolvedType & that) const

--- a/Birdee/Preprocessing.cpp
+++ b/Birdee/Preprocessing.cpp
@@ -2913,12 +2913,16 @@ If usage vararg name is "", match the closest vararg
 		{
 			if (auto indexexpr = dyncast_resolve_anno<IndexExprAST>(Callee.get()))
 			{
+				if(auto member = dyncast_resolve_anno<MemberExprAST>(indexexpr->Expr.get()))
+					preserved_member_obj = &member->Obj;
 				indexexpr->Phase1(true);
 				if (auto idxexpr = dyncast_resolve_anno<FunctionTemplateInstanceExprAST>(indexexpr->instance.get()))
 					func = idxexpr->instance;
 			}
 			else if (auto templexpr = dyncast_resolve_anno<FunctionTemplateInstanceExprAST>(Callee.get()))
 			{
+				if(auto member = dyncast_resolve_anno<MemberExprAST>(templexpr->expr.get()))
+					preserved_member_obj = &member->Obj;
 				templexpr->Phase1(true);
 				func = templexpr->instance;
 			}
@@ -2936,15 +2940,6 @@ If usage vararg name is "", match the closest vararg
 			{
 				ValidateOneTemplateArg(*e.args, func->template_param->params, Pos, i);
 				name2type[func->template_param->params[i].name] = std::move(e.args->at(i));
-			}
-			FunctionTemplateInstanceExprAST* templ = nullptr;
-			if (auto indexexpr = dyncast_resolve_anno<IndexExprAST>(Callee.get()))
-				templ = dyncast_resolve_anno<FunctionTemplateInstanceExprAST>(indexexpr->instance.get());
-			else 
-				templ = dyncast_resolve_anno<FunctionTemplateInstanceExprAST>(Callee.get());
-			{
-				if (auto member = dyncast_resolve_anno<MemberExprAST>(templexpr->expr.get()))
-					preserved_member_obj = &member->Obj;
 			}
 		}
 

--- a/Birdee/PythonBinding2.cpp
+++ b/Birdee/PythonBinding2.cpp
@@ -90,7 +90,7 @@ static_assert(sizeof(py::object) == sizeof(void*), "expecting sizeof(py::object)
 
 
 
-BIRDEE_BINDING_API void RunGenerativeScript()
+BIRDEE_BINDING_API int RunGenerativeScript()
 {
 	try
 	{
@@ -99,11 +99,14 @@ BIRDEE_BINDING_API void RunGenerativeScript()
 	catch (py::error_already_set& e)
 	{
 		std::cerr<<e.what();
+		return 1;
 	}
 	catch (std::runtime_error& e)
 	{
 		std::cerr << e.what();
+		return 2;
 	}
+	return 0;
 }
 /*the python internal data structure, for debug use*/
 /*

--- a/Birdee/include/BdAST.h
+++ b/Birdee/include/BdAST.h
@@ -953,17 +953,19 @@ namespace Birdee {
 		ResolvedType resolved_type;
 		std::unique_ptr<VariableDefAST> Args;
 		vector<unique_ptr<VariableSingleDefAST>> resolved_args;
-		llvm::FunctionType* GenerateFunctionType();
-		llvm::DIType* GenerateDebugType();
+		//gen_closure: force to generate a closure
+		llvm::FunctionType* GenerateFunctionType(bool gen_closure = false);
+		llvm::DIType* GenerateDebugType(bool gen_closure = false);
 		//Put the definitions of arguments into a vector
 		//resolve the types in the arguments and the returned value 
 		void Phase0();
 
 		void Phase1(bool register_in_basic_block);
 		PrototypeAST(const std::string &Name, vector<unique_ptr<VariableSingleDefAST>>&& ResolvedArgs, const ResolvedType& ResolvedType, ClassAST* cls, int prefix_idx, bool is_closure)
-			: Name(Name), Args(nullptr), RetType(nullptr), cls(cls), pos(0,0,0), resolved_args(std::move(ResolvedArgs)), resolved_type(ResolvedType),prefix_idx(prefix_idx), is_closure(is_closure){}
+			: Name(Name), Args(nullptr), RetType(nullptr), cls(cls), pos(0,0,0), resolved_args(std::move(ResolvedArgs)),
+			resolved_type(ResolvedType),prefix_idx(prefix_idx), is_closure(cls || is_closure){}
 		PrototypeAST(const std::string &Name, std::unique_ptr<VariableDefAST>&& Args, std::unique_ptr<Type>&& RetType,ClassAST* cls,SourcePos pos, bool is_closure)
-			: Name(Name), Args(std::move(Args)), RetType(std::move(RetType)),pos(pos),cls(cls), is_closure(is_closure){}
+			: Name(Name), Args(std::move(Args)), RetType(std::move(RetType)),pos(pos),cls(cls), is_closure(cls || is_closure){}
 
 		const std::string &GetName() const { return Name; }
 		void print(int level)
@@ -1334,6 +1336,10 @@ namespace Birdee {
 			member_imported_function,
 			member_virtual_function,
 		}kind;
+		bool isMemberFunction();
+		llvm::Value* GenerateFunction();
+		//generate the object, returns the field_offset of the object
+		int GenerateObj();
 		void Phase1();
 		bool isMutable() {
 			return kind == member_field || kind==member_imported_dim;

--- a/Birdee/include/BdAST.h
+++ b/Birdee/include/BdAST.h
@@ -834,7 +834,7 @@ namespace Birdee {
 		std::unique_ptr<ExprAST> val;
 		ResolvedType resolved_type;
 
-		//the capture index in the "context" object
+		//the capture index in the "context" object, you need to add 1 to it if there is a captured "this"
 		int capture_import_idx = -1;
 		int capture_export_idx = -1;
 		enum CaptureType

--- a/BirdeeHome/pylib/bbuild.py
+++ b/BirdeeHome/pylib/bbuild.py
@@ -302,7 +302,8 @@ def init_path():
 
 def link_msvc():
 	linker_path='link.exe'
-	msvc_command='''{} /OUT:"{}" /MANIFEST /NXCOMPAT /PDB:"{}" {} /DYNAMICBASE {} "kernel32.lib" "user32.lib" "gdi32.lib" "winspool.lib" "comdlg32.lib" "advapi32.lib" "shell32.lib" "ole32.lib" "oleaut32.lib" "uuid.lib" "odbc32.lib" "odbccp32.lib" /DEBUG /MACHINE:X64 /INCREMENTAL /SUBSYSTEM:CONSOLE /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /ManifestFile:"{}" /ERRORREPORT:PROMPT /NOLOGO /TLBID:1 '''
+	#removed flag: /INCREMENTAL
+	msvc_command='''{} /OUT:"{}" /MANIFEST /NXCOMPAT /PDB:"{}" {} /DYNAMICBASE {} "kernel32.lib" "user32.lib" "gdi32.lib" "winspool.lib" "comdlg32.lib" "advapi32.lib" "shell32.lib" "ole32.lib" "oleaut32.lib" "uuid.lib" "odbc32.lib" "odbccp32.lib" /DEBUG /MACHINE:X64  /SUBSYSTEM:CONSOLE /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /ManifestFile:"{}" /ERRORREPORT:PROMPT /NOLOGO /TLBID:1 '''
 	runtime_lib_path = os.path.join(bd_home,"bin","BirdeeRuntime.lib")
 	pdb_path= os.path.splitext(link_target)[0]+".pdb"
 	obj_files='"{runtime_lib_path}"'.format(runtime_lib_path=runtime_lib_path)

--- a/BirdeeHome/pylib/bdutils.py
+++ b/BirdeeHome/pylib/bdutils.py
@@ -82,23 +82,32 @@ def get_func_arg_at(func,idx):
 	return args[idx]
 
 
-def get_func_templ_at(idx):
-	thecls = get_cur_func()
-	require_(is_template_inst(thecls), index_within(idx,0,len(thecls.template_instance_args)))
-	return thecls.template_instance_args[idx]
+def get_func_templ_at(idx, thefunc = None):
+	if not thefunc:
+		thefunc = get_cur_func()
+	require_(is_template_inst(thefunc), index_within(idx,0,len(thefunc.template_instance_args)))
+	return thefunc.template_instance_args[idx]
 
-def get_func_type_templ_at(idx):
-	arg = get_func_templ_at(idx)
+def get_func_type_templ_at(idx, thefunc = None):
+	if not thefunc:
+		thefunc = get_cur_func()
+	arg = get_func_templ_at(idx, thefunc)
 	require_(is_type_templ_arg(arg,idx))
 	return arg.resolved_type
 
-def get_func_expr_templ_at(idx):
-	arg = get_func_templ_at(idx)
+def get_func_expr_templ_at(idx, thefunc = None):
+	if not thefunc:
+		thefunc = get_cur_func()
+	arg = get_func_templ_at(idx, thefunc)
 	require_(is_expr_templ_arg(arg,idx))
 	return arg.expr
 
-def func_templ_type_at(idx):
-	set_type(get_func_type_templ_at(idx))
+def func_templ_type_at(idx, thefunc = None):
+	if not thefunc:
+		thefunc = get_cur_func()
+	set_type(get_func_type_templ_at(idx, thefunc))
 
-def func_templ_expr_at(idx):
-	set_ast(get_func_expr_templ_at(idx))
+def func_templ_expr_at(idx, thefunc = None):
+	if not thefunc:
+		thefunc = get_cur_func()
+	set_ast(get_func_expr_templ_at(idx, thefunc))

--- a/BirdeeHome/src/birdee.txt
+++ b/BirdeeHome/src/birdee.txt
@@ -108,13 +108,9 @@ class runtime_exception
 	@virtual public func get_message() as string => msg
 end
 
-declare function BirdeeI2S (i as int) as string
-declare function BirdeeP2S (i as pointer) as string
-declare function BirdeeD2S (i as double) as string
-
-function int2str(i as int) as string
-	return BirdeeI2S(i)
-end
+declare function int2str alias "BirdeeI2S" (i as int) as string
+declare function pointer2str alias "BirdeeP2S" (i as pointer) as string
+declare function double2str alias "BirdeeD2S" (i as double) as string
 
 function bool2str(i as boolean) as string
 	if i then

--- a/BirdeeHome/src/concurrent/threading.bdm
+++ b/BirdeeHome/src/concurrent/threading.bdm
@@ -1,31 +1,17 @@
 package concurrent
 
+import functional.closures:*
 import unsafe
 
-struct closure_unpacked
-	public funcptr as pointer
-	public data as pointer
-end
+
 
 @init_script
 {@
 from traits import *
 from traits import _
 from bdutils import *
-
+from functional_0closures import *
 osname =  get_os_name()
-def check_arg_is_functype(idx):
-	def checker(fn):
-		ty = get_func_arg_at(fn,0).resolved_type
-		require_(is_prototype(ty))
-	return checker
-
-def check_arg_is_closure(idx):
-	def checker(fn):
-		ty = get_func_arg_at(fn,0).resolved_type
-		require_(is_prototype(ty))
-		require_( (ty.get_detail().is_closure, lambda:"Expecting a closure"))
-	return checker
 
 def expand_vararg(func, idx_start):
 	args = func.proto.args
@@ -35,16 +21,7 @@ def expand_vararg(func, idx_start):
 	return ret[:-1]
 @}
 
-@check_arg_is_closure(0)
-function unpack_closure[T](f as T) as closure_unpacked => unsafe.ptr_load[closure_unpacked](addressof(f))
 
-#@check_arg_is_closure(0)
-function pack_closure[TClosure, T](obj as T, funct as pointer) as TClosure 
-	dim v as closure_unpacked
-	v.funcptr = funct
-	v.data = pointerof(obj)
-	return unsafe.ptr_load[TClosure](addressof(v))
-end
 
 {@
 os_function_decl = {
@@ -104,7 +81,7 @@ class thread
 	public function __init__[T,...](fn as T, ...)
 {@
 func=get_cur_func()
-check_arg_is_functype(0)(func)
+check_templ_arg_is_functype(0)(func)
 @}
 		dim f = function ()
 			{@set_ast(expr("fn({})".format(expand_vararg(func,1))))@}

--- a/BirdeeHome/src/concurrent/threading.bdm
+++ b/BirdeeHome/src/concurrent/threading.bdm
@@ -10,6 +10,7 @@ import unsafe
 from traits import *
 from traits import _
 from bdutils import *
+imports("functional.closures")
 from functional_0closures import *
 osname =  get_os_name()
 

--- a/BirdeeHome/src/concurrent/threading.bdm
+++ b/BirdeeHome/src/concurrent/threading.bdm
@@ -16,13 +16,13 @@ from bdutils import *
 osname =  get_os_name()
 def check_arg_is_functype(idx):
 	def checker(fn):
-		ty = get_function_arg_at(fn,0).resolved_type
+		ty = get_func_arg_at(fn,0).resolved_type
 		require_(is_prototype(ty))
 	return checker
 
 def check_arg_is_closure(idx):
 	def checker(fn):
-		ty = get_function_arg_at(fn,0).resolved_type
+		ty = get_func_arg_at(fn,0).resolved_type
 		require_(is_prototype(ty))
 		require_( (ty.get_detail().is_closure, lambda:"Expecting a closure"))
 	return checker

--- a/BirdeeHome/src/concurrent/threading.bdm
+++ b/BirdeeHome/src/concurrent/threading.bdm
@@ -38,6 +38,14 @@ def expand_vararg(func, idx_start):
 @check_arg_is_closure(0)
 function unpack_closure[T](f as T) as closure_unpacked => unsafe.ptr_load[closure_unpacked](addressof(f))
 
+#@check_arg_is_closure(0)
+function pack_closure[TClosure, T](obj as T, funct as pointer) as TClosure 
+	dim v as closure_unpacked
+	v.funcptr = funct
+	v.data = pointerof(obj)
+	return unsafe.ptr_load[TClosure](addressof(v))
+end
+
 {@
 os_function_decl = {
 	'windows':{

--- a/BirdeeHome/src/functional/closures.bdm
+++ b/BirdeeHome/src/functional/closures.bdm
@@ -1,0 +1,38 @@
+package functional
+
+struct closure_unpacked
+	public funcptr as pointer
+	public data as pointer
+end
+
+@init_script
+{@
+from traits import *
+from traits import _
+from bdutils import *
+
+def check_templ_arg_is_functype(idx):
+	def checker(fn):
+		ty = get_func_type_templ_at(0,fn)
+		require_(is_prototype(ty))
+	return checker
+
+def check_templ_arg_is_closure(idx):
+	def checker(fn):
+		ty = get_func_type_templ_at(0,fn)
+		require_(is_prototype(ty))
+		require_( (ty.get_detail().is_closure, lambda:"Expecting a closure"))
+	return checker
+@}
+
+@check_templ_arg_is_closure(0)
+function unpack_closure[T](f as T) as closure_unpacked => unsafe.ptr_load[closure_unpacked](addressof(f))
+
+@check_templ_arg_is_closure(0)
+function pack_closure[TClosure, T](obj as T, funct as pointer) as TClosure 
+	dim v as closure_unpacked
+	v.funcptr = funct
+	v.data = pointerof(obj)
+	return unsafe.ptr_load[TClosure](addressof(v))
+end
+

--- a/BirdeeHome/src/functional/option.txt
+++ b/BirdeeHome/src/functional/option.txt
@@ -23,7 +23,7 @@ if T_is_not_reference():
 	class_body(get_cur_class(),"private _defined as boolean\n")
 	set_expr("_defined")
 else:
-	set_expr("obj!=null")
+	set_expr("obj!==null")
 @}
 	end
 	public function set(o as T)

--- a/BirdeeHome/src/functional/option.txt
+++ b/BirdeeHome/src/functional/option.txt
@@ -3,68 +3,86 @@ package functional
 @init_script
 {@
 from traits import *
-def check_option(cls):
+from bdutils import *
+def T_is_not_reference():
+	cls=get_cur_class()
 	targ = cls.template_instance_args[0]
 	assert(targ.kind==TemplateArgument.TemplateArgumentType.TEMPLATE_ARG_TYPE)
 	type = targ.resolved_type
-	if type.index_level==0 and (type.base!=BasicType.CLASS or type.get_detail().is_struct):
-		raise RuntimeError("option can only hold references. However, T is {}".format(type))
-
-def check_if_is_option(type):
-	option_class = get_cur_func().proto.cls.template_source_class
-	cls=type.get_detail()
-	if not isinstance(cls,ClassAST):
-		raise RuntimeError("Expecting a function that returns an option. However, the return type is {}".format(cls.get_unique_name()))
-	chk_src_class = cls.template_source_class
-	if chk_src_class != option_class:
-		raise RuntimeError("Expecting a function that returns an option. However, the return type is {}".format(cls.get_unique_name()))
+	if type.base==BasicType.VOID :
+		raise RuntimeError("T for option cannot be void")
+	return type.index_level==0 and (type.base!=BasicType.CLASS or type.get_detail().is_struct)
+		
 @}
 
-@check_option
 struct option[T]
 	private obj as T
-	
-	public function set(o as T) => obj = o
+	public function is_defined() as boolean
+return {@
+if T_is_not_reference():
+	class_body(get_cur_class(),"private _defined as boolean\n")
+	set_expr("_defined")
+else:
+	set_expr("obj!=null")
+@}
+	end
+	public function set(o as T)
+		obj = o
+{@
+if T_is_not_reference():
+	set_stmt("_defined = true")
+@}
+	end
+
+	public function reset()
+{@
+if T_is_not_reference():
+	set_stmt("_defined = false")
+else:
+	set_stmt("obj = null")
+@}
+	end
+
 	public function get() as T => obj
 	public function or_else(other as T) as T
-		if obj===null then
-			return other
-		else
+		if is_defined() then
 			return obj
+		else
+			return other
 		end
 	end
 
 	public function map[T2](map_func as closure(v as T) as T2) as option[T2]
 		dim ret as option[T2]
-		if obj!==null then
+		if is_defined() then
 			ret.set(map_func(obj))
 		else
-			ret.set(null)
+			ret.reset()
 		end
 		return ret
 	end
 
 	public function for_each(map_func as closure(v as T))
-		if obj!==null then
+		if is_defined() then
 			map_func(obj)
 		end
 	end
 
 	public function flat_map[T2](map_func as closure(v as T) as option[T2]) as option[T2]
-		if obj!==null then
+		if is_defined() then
 			return map_func(obj)
 		end
 		dim ret as option[T2]
-		ret.set(null)
+		ret.reset()
 		return ret
 	end
 
 	public function filter(predicate as closure (obj as T) as boolean) as option[T]
-		if obj!==null && predicate(obj) then
+		if is_defined() && predicate(obj) then
 			return this 
 		end
 		dim ret as option[T]
-		ret.set(null)
+		ret.reset()
 		return ret
 	end
 
@@ -78,7 +96,7 @@ end
 
 function none[T]() as option[T]
 	dim ret as option[T]
-	ret.set(null)
+	ret.reset()
 	return ret
 end
 

--- a/BirdeeHome/src/reflection.bdm
+++ b/BirdeeHome/src/reflection.bdm
@@ -1,23 +1,25 @@
 import hash:hash_map
-import concurrent.threading:unpack_closure
-import concurrent.threading:pack_closure
+import functional.closures:unpack_closure
+import functional.closures:pack_closure
 import functional.option:*
 import unsafe:*
 
 @init_script
 {@
 from bdutils import *
+from functional_0closures import check_templ_arg_is_functype
 @}
 class class_metadata
     public name as string
     public func_map as hash_map[string, pointer]
     public function __init__() => func_map = new hash_map[string, pointer]
-    public function get_function[TClosure, TObj](obj as TObj, fname as string) as option[TClosure]
+    public function get_function[TClosure](fname as string) as option[TClosure]
+{@check_templ_arg_is_functype(0)(get_cur_func())@}
         dim itr = func_map.find(fname)
         if itr == func_map.ends() then
             return none[TClosure]()
         else
-            return some(pack_closure[TClosure](obj, itr.getv()))
+            return some(bit_cast[TClosure](itr.getv()))
         end
     end
 end
@@ -40,6 +42,6 @@ end
 
 register[string]()
 dim m = class_reflect_map["string"]
-closure clotype() as uint
-dim clo = m.get_function[clotype]("a", "length").get()
-println(int2str(clo()))
+functype clotype(v as string) as uint
+dim clo as clotype = m.get_function[clotype]("length").get()
+println(int2str(clo("hello")))

--- a/BirdeeHome/src/reflection.bdm
+++ b/BirdeeHome/src/reflection.bdm
@@ -1,0 +1,45 @@
+import hash:hash_map
+import concurrent.threading:unpack_closure
+import concurrent.threading:pack_closure
+import functional.option:*
+import unsafe:*
+
+@init_script
+{@
+from bdutils import *
+@}
+class class_metadata
+    public name as string
+    public func_map as hash_map[string, pointer]
+    public function __init__() => func_map = new hash_map[string, pointer]
+    public function get_function[TClosure, TObj](obj as TObj, fname as string) as option[TClosure]
+        dim itr = func_map.find(fname)
+        if itr == func_map.ends() then
+            return none[TClosure]()
+        else
+            return some(pack_closure[TClosure](obj, itr.getv()))
+        end
+    end
+end
+
+dim class_reflect_map = new hash_map[string, class_metadata]
+
+function register[T]()
+    dim meta = new class_metadata
+    {@T = get_func_type_templ_at(0).get_detail()@}
+    meta.name = {@set_str(T.name)@}
+    {@
+funcs = []
+for func in T.funcs:
+    if func.access == AccessModifier.PUBLIC:
+        funcs.append("meta.func_map.insert(\"{name}\", unpack_closure(ptr_cast[T](null).{name}).funcptr)".format(name=func.decl.proto.name))
+set_stmt("if true then\n"+"\n".join(funcs) + "\nend\n")
+    @}
+    class_reflect_map.insert(meta.name, meta)
+end
+
+register[string]()
+dim m = class_reflect_map["string"]
+closure clotype() as uint
+dim clo = m.get_function[clotype]("a", "length").get()
+println(int2str(clo()))

--- a/BirdeePlayground/BirdeeIncludes.h
+++ b/BirdeePlayground/BirdeeIncludes.h
@@ -117,6 +117,15 @@ jit->addNative("system_0io_0filedef_0file__exception_0get__message",system_0io_0
 extern void system_0io_0filedef_0_1main();
 jit->addNative("system_0io_0filedef_0_1main",system_0io_0filedef_0_1main);
 
+extern void system_0io_0stdio_0stderr();
+jit->addNative("system_0io_0stdio_0stderr",system_0io_0stdio_0stderr);
+
+extern void system_0io_0stdio_0stdin();
+jit->addNative("system_0io_0stdio_0stdin",system_0io_0stdio_0stdin);
+
+extern void system_0io_0stdio_0stdout();
+jit->addNative("system_0io_0stdio_0stdout",system_0io_0stdio_0stdout);
+
 extern void system_0io_0stdio_0_1main();
 jit->addNative("system_0io_0stdio_0_1main",system_0io_0stdio_0_1main);
 
@@ -144,14 +153,11 @@ jit->addNative("system_0specific_0win32_0file_0__getstd",system_0specific_0win32
 extern void system_0specific_0win32_0file_0_1main();
 jit->addNative("system_0specific_0win32_0file_0_1main",system_0specific_0win32_0file_0_1main);
 
-extern void birdee_0print();
-jit->addNative("birdee_0print",birdee_0print);
-
-extern void birdee_0int2str();
-jit->addNative("birdee_0int2str",birdee_0int2str);
-
 extern void birdee_0bool2str();
 jit->addNative("birdee_0bool2str",birdee_0bool2str);
+
+extern void birdee_0print();
+jit->addNative("birdee_0print",birdee_0print);
 
 extern void birdee_0println();
 jit->addNative("birdee_0println",birdee_0println);

--- a/BirdeePlayground/Makefile
+++ b/BirdeePlayground/Makefile
@@ -1,7 +1,8 @@
 all: $(BIN_DIR)/birdeeplay
 
 $(BIN_DIR)/birdeeplay: BirdeePlayground.o
-	$(CXX) -o $@ $(CPPFLAGS)  -L$(LIB_DIR) -Wl,--export-dynamic -Wl,--start-group BirdeePlayground.o $(BLIB_DIR)/../blib/birdee.o $(BLIB_DIR)/../blib/hash.o $(BLIB_DIR)/../blib/concurrent/threading.o $(BLIB_DIR)/../blib/string_buffer.o -lBirdeeCompilerCore -lBirdeeRuntime -lLLVM-6.0 -ldl -lpthread -lgc -Wl,--end-group -Wl,-rpath='$$ORIGIN/../lib/'
+	$(CXX) -o $@ $(CPPFLAGS)  -L$(LIB_DIR) -Wl,--export-dynamic -Wl,--start-group BirdeePlayground.o $(BLIB_DIR)/../blib/birdee.o $(BLIB_DIR)/../blib/hash.o $(BLIB_DIR)/../blib/concurrent/threading.o $(BLIB_DIR)/../blib/string_buffer.o $(BLIB_DIR)/../blib/system/io/file.o \
+$(BLIB_DIR)/../blib/system/io/filedef.o $(BLIB_DIR)/../blib/system/io/stdio.o $(BLIB_DIR)/../blib/system/specific/unistd/file.o -lBirdeeCompilerCore -lBirdeeRuntime -lLLVM-6.0 -ldl -lpthread -lgc -Wl,--end-group -Wl,-rpath='$$ORIGIN/../lib/'
 .PHONY:clean remake
 
 

--- a/BirdeePlayground/gentable.py
+++ b/BirdeePlayground/gentable.py
@@ -46,6 +46,11 @@ def parse_bmm(*pkg):
 	with open(os.path.join(os.environ['BIRDEE_HOME'],'blib',*pkg) + '.bmm') as f:
 		data = json.load(f)
 		pkgname = '.'.join(pkg) + '.'
+		for var in data['Variables']:
+			fstr=""
+			fstr=mangle_func(pkgname+var['name'])
+			print(fstr)
+			outf.write(get_code(fstr))
 		for func in data['Functions']:
 			fstr=""
 			if 'link_name' in func:

--- a/tests/ast_write_test.py
+++ b/tests/ast_write_test.py
@@ -48,7 +48,7 @@ def check_return(func):
 
 @return_123
 @check_return
-function func() as float
+function funct() as float
 	return 1
 end
 ''')

--- a/tests/class_inherit_import.txt
+++ b/tests/class_inherit_import.txt
@@ -13,5 +13,3 @@ b.say("hello")
 d.say("hello2")
 d.speak("hello")
 println("import test ends")
-
-getchar()

--- a/tests/class_inherit_test.txt
+++ b/tests/class_inherit_test.txt
@@ -125,7 +125,6 @@ println(int2str(ts.add22(10)))
 
 println(int2str(ts.pubget()))
 
-getchar()
 println("=============")
 
 println(int2str(ts.pa))
@@ -190,5 +189,3 @@ b.say("test")
 d.say("test2")
 d.speak("speak test")
 println("End")
-
-getchar()

--- a/tests/container_test.txt
+++ b/tests/container_test.txt
@@ -216,6 +216,5 @@ queue_test()
 stack_test()
 
 println("Done")
-getchar()
 
 

--- a/tests/exception_test.txt
+++ b/tests/exception_test.txt
@@ -40,8 +40,8 @@ function f1()
 	catch e as E2
 		e.print()
 		as_instance[E3](e).for_each(func (e3 as E3) => println(int2str(e3.dummy2)))
-	##catch e as E3
-		e.print()##
+	catch e as E3
+		e.print()
 	end
 	println("Continue")
 end
@@ -69,4 +69,4 @@ func aaa()
 	f()
 end
 
-aaa()
+#aaa()

--- a/tests/file_test.bdm
+++ b/tests/file_test.bdm
@@ -7,13 +7,13 @@ from system_0io_0filedef import *
 from bdassert import bdassert
 @}
 
-dim outf = new output_file("tests/file_text.log", {@CREATE_OVERWRITE()@})
+dim outf = new output_file("bin/file_text.log", {@CREATE_OVERWRITE()@})
 for dim i=0 to 1000
 	outf.writestr(int2str(i)+"\n")
 end
 outf.close()
 
-dim scanner = new string_scanner(new input_file("tests/file_text.log"))
+dim scanner = new string_scanner(new input_file("bin/file_text.log"))
 #dim scanner = new string_scanner(stdin)
 
 dim str as string = scanner.get_line()

--- a/tests/file_test.bdm
+++ b/tests/file_test.bdm
@@ -1,5 +1,5 @@
-import system.io.file:*
 import system.io.stdio:*
+import system.io.file:*
 import system.io.filedef
 
 {@

--- a/tests/functype_test.txt
+++ b/tests/functype_test.txt
@@ -1,46 +1,38 @@
-##
 import test_package.b.functype_test_lib:*
 
+{@from bdassert import bdassert@}
 #pfunc(3,4)
 
 dim fa as tyfunc=function (a as int, b as int) as int => a-b
 
-fa(4,5)
+{@bdassert("fa(4,5)==0-1")@}
 
 dim fb as test_package.b.functype_test_lib.tyfunc=fa
 
-fb(3,2)
+{@bdassert("fb(3,2)==1")@}
 
-function caller(fun as tyfunc, a as int)
-	fun(a,3)
+
+function caller(fun as tyfunc, a as int) as int
+	return fun(a,3)
 end
 
-caller(function (a as int, b as int) as int => a*b ,  23)
+{@bdassert("caller(function (a as int, b as int) as int => a*b ,  23)==69")@}
 
-##
-
-closure consumer () 
 
 {@
 def dummy(f):
 	print(f)
 @}
 
-function aaa () as consumer
-	dim a=1,b=2
-	dim fun as consumer = function() => println("hello")
-	fun()
-	function my_function()
-	end
-	return function () => println(int2str(a+b))
-end
-
+dim result as int = 0
+closure consumer () 
 
 class clsa
 	private a as int
 	public function aaa()
 		dim b as int=3
-		dim fun as consumer = function () => println(int2str(a+b))
+		dim c as int =0
+		dim fun as consumer = function () => result = a + b + c
 		fun()			
 	end
 
@@ -49,21 +41,39 @@ class clsa
 	end
 end
 
+
+function aaa () as consumer
+	dim a=1,b=2
+	dim fun as consumer = function()
+		println("hello")
+		result=1
+	end
+	fun()
+	function my_function()
+	end
+	return function () => result =result + a+b
+end
+
+
+
+
 dim a = aaa()
 a()
+{@bdassert("result==4")@}
+
 dim b as clsa = new clsa
 (@dummy (b.aaa) )()
+{@bdassert("result==126")@}
+
 
 
 
 function nested(d as int) as consumer
 	dim a=1,b=2
-	dim fun as consumer = @stack_capture function my_function()
-		dim f = function ()
-			dim str as string
-			dim f2 = @stack_capture function(c as int) as string => int2str(a+b+c+d)
-			str=f2(3)
-			println(str)
+	dim fun as consumer = function my_function()
+		dim f = @stack_capture function ()
+			dim f2 = @stack_capture function(c as int) as int=> a+b+c+d
+			result=f2(3)
 		end
 		f()
 	end
@@ -71,3 +81,4 @@ function nested(d as int) as consumer
 end
 
 nested(3)()
+{@bdassert("result==9")@} 

--- a/tests/gc_test.txt
+++ b/tests/gc_test.txt
@@ -1,17 +1,25 @@
 dim i=0
 dim a =new ulong*128
+dim instances = 0
+
+{@from bdassert import bdassert@}
 class clstest
 	public a as int
 	public function __init__(va as int)
 		a=va
+		instances = instances +1
 	end
 	public function __del__()
-		println("finalizer"+int2str(a))
+		#println("finalizer"+int2str(a))
+		instances = instances  - 1
 	end	
 end
-breakpoint()
-while true
-	println("Hello"+int2str(i))
+
+println("creating many objects...")
+for i =0 to 10000
+	dim tmp = "Hello"+int2str(i)
 	a[0]=1
 	new clstest(32)
 end
+println("# of instances = " + int2str(instances))
+{@bdassert("instances<10000")@}

--- a/tests/hardware_exception_test.txt
+++ b/tests/hardware_exception_test.txt
@@ -1,3 +1,5 @@
+{@from bdassert import bdassert@}
+
 func test()
 	dim a as string=null
 	println(a)
@@ -7,6 +9,7 @@ end
 func wrapper1()
 	try
 		test()
+		{@bdassert("false")@}
 	catch e as mem_access_exception
 		println("Caught SEGV")
 	end
@@ -23,18 +26,29 @@ func test2[T]() as T
 	return 2/a
 end
 
-
+dim triggered = false
 func wrapper2[T,STR as string]()
 	try
 		test2[T]()
 	catch e as div_zero_exception
 		println(STR)
+		triggered = true
 	end
 end
 
+func check_triggered()
+	if !triggered then
+		{@bdassert("false")@}
+	end
+	triggered = false
+end
+
 wrapper2[int,"int"]()
+check_triggered()
 wrapper2[int,"int"]()
+check_triggered()
 wrapper2[int,"int"]()
+check_triggered()
 
 println("Test done")
 

--- a/tests/hash_map_test.txt
+++ b/tests/hash_map_test.txt
@@ -1,7 +1,0 @@
-import hash_map:hash_map
-
-dim map = new hash_map[string,int]:create()
-map.set("123",321)
-println(int2str(map.get_pair("123").value))
-
-#--printir -i D:\Menooker\CXX\Birdee\tests\hash_map_test.txt -o .\hash_map_test.obj  -e

--- a/tests/import_test.txt
+++ b/tests/import_test.txt
@@ -1,0 +1,8 @@
+import test_package.b.mod2
+import test_package.a.mod1
+
+{@from bdassert import bdassert@}
+dim o = new test_package.a.mod1.some_class(2.3)
+{@bdassert("o.b==2.3")@}
+{@bdassert("o.get()==2.3")@}
+{@bdassert("test_package.a.mod1.funct()==\"HAHA\"")@}

--- a/tests/logic_obj_cmp.txt
+++ b/tests/logic_obj_cmp.txt
@@ -1,18 +1,46 @@
-dim a as string, b as string
-a==b
-a===b
-a!=b
-a="hello"
+{@from bdassert import bdassert@}
+dim a as string="1", b as string = int2str(1)
+dim r = a==b
+{@bdassert("r")@}
+r = a===b
+{@bdassert("!r")@}
+r = a!=b
+{@bdassert("!r")@}
+r = a!==b
+{@bdassert("r")@}
 
+dim v = 1
+func side_effect() as boolean
+	v = v + 1
+	return false
+end
 dim c =true
-c= c | true
-c= c & true
-c= c && (a==b)
-c= c || (a==b)
+c= c | side_effect()
+{@bdassert("c")@}
+{@bdassert("v==2")@}
+
+c= c & side_effect()
+{@bdassert("!c")@}
+{@bdassert("v==3")@}
+c=true
+
+c= c && side_effect()
+{@bdassert("!c")@}
+{@bdassert("v==4")@}
+
+c= side_effect() && side_effect()
+{@bdassert("!c")@}
+{@bdassert("v==5")@}
+
+c=true
+c= c || side_effect()
+{@bdassert("c")@}
+{@bdassert("v==5")@}
 
 dim d=1
 d=d | 123
 d=d ^ 123
+{@bdassert("d==0")@}
 
 #d=d&&1
 #0.123 | 32

--- a/tests/makefile2.mak
+++ b/tests/makefile2.mak
@@ -1,5 +1,9 @@
 
-all: $(OUT_DIR) class_inherit_import.test container_test.test exception_test.test threading_test.test
+all: $(OUT_DIR) class_inherit_import.test container_test.test exception_test.test file_test.test \
+    functype_test.test gc_test.test hardware_exception_test.test import_test.test logic_obj_cmp.test operators.test \
+	rtti2.test template_link_test.test threading_test.test typedptr_test.test vector_test.test \
+	ast_write_test.pytest scripttest.pytest template_vararg.pytest getset_test.pytest \
+	py_module_test.module
 SRC_DIR=.
 OUT_DIR=bin
 
@@ -7,7 +11,7 @@ OUT_DIR=bin
 $(OUT_DIR):
 	cmd /c "if not exist $@ mkdir $@"
 
-.SUFFIXES : .test .txt .bdm
+.SUFFIXES : .test .txt .bdm .py .pytest .module
 
 .txt.test: 
 	python3 $(BIRDEE_HOME)\pylib\bbuild.py -i $(SRC_DIR) -o $(OUT_DIR) -le $(OUT_DIR)\$*.exe $*
@@ -17,9 +21,21 @@ $(OUT_DIR):
 	python3 $(BIRDEE_HOME)\pylib\bbuild.py -i $(SRC_DIR) -o $(OUT_DIR) -le $(OUT_DIR)\$*.exe $*
 	$(OUT_DIR)\$*.exe
 
+.py.pytest:
+	$(BIRDEE_HOME)\bin\birdeec.exe -s -i $*.py -o bin\$*.obj
+
+.txt.module: 
+	python3 $(BIRDEE_HOME)\pylib\bbuild.py -i $(SRC_DIR) -o $(OUT_DIR) $*
+
+.bdm.module: 
+	python3 $(BIRDEE_HOME)\pylib\bbuild.py -i $(SRC_DIR) -o $(OUT_DIR) $*
+
 clean:
-	del $(OUT_DIR)\*.bmm
-	del $(OUT_DIR)\*.obj
-	del $(OUT_DIR)\*.exe
+	del /S $(OUT_DIR)\*.bmm
+	del /S $(OUT_DIR)\*.obj
+	del /S $(OUT_DIR)\*.exe
+	del /S $(OUT_DIR)\*.log
+	del /S $(OUT_DIR)\*.pdb
+	del /S $(OUT_DIR)\*.manifest
 
 remake: clean all

--- a/tests/makefile2.mak
+++ b/tests/makefile2.mak
@@ -1,5 +1,5 @@
 
-all: $(OUT_DIR) class_inherit_import.test container_test.test exception_test.test
+all: $(OUT_DIR) class_inherit_import.test container_test.test exception_test.test threading_test.test
 SRC_DIR=.
 OUT_DIR=bin
 
@@ -7,9 +7,13 @@ OUT_DIR=bin
 $(OUT_DIR):
 	cmd /c "if not exist $@ mkdir $@"
 
-.SUFFIXES : .test .txt
+.SUFFIXES : .test .txt .bdm
 
 .txt.test: 
+	python3 $(BIRDEE_HOME)\pylib\bbuild.py -i $(SRC_DIR) -o $(OUT_DIR) -le $(OUT_DIR)\$*.exe $*
+	$(OUT_DIR)\$*.exe
+
+.bdm.test: 
 	python3 $(BIRDEE_HOME)\pylib\bbuild.py -i $(SRC_DIR) -o $(OUT_DIR) -le $(OUT_DIR)\$*.exe $*
 	$(OUT_DIR)\$*.exe
 

--- a/tests/makefile2.mak
+++ b/tests/makefile2.mak
@@ -1,0 +1,21 @@
+
+all: $(OUT_DIR) class_inherit_import.test container_test.test exception_test.test
+SRC_DIR=.
+OUT_DIR=bin
+
+
+$(OUT_DIR):
+	cmd /c "if not exist $@ mkdir $@"
+
+.SUFFIXES : .test .txt
+
+.txt.test: 
+	python3 $(BIRDEE_HOME)\pylib\bbuild.py -i $(SRC_DIR) -o $(OUT_DIR) -le $(OUT_DIR)\$*.exe $*
+	$(OUT_DIR)\$*.exe
+
+clean:
+	del $(OUT_DIR)\*.bmm
+	del $(OUT_DIR)\*.obj
+	del $(OUT_DIR)\*.exe
+
+remake: clean all

--- a/tests/operators.txt
+++ b/tests/operators.txt
@@ -1,4 +1,5 @@
-##class complex
+{@from bdassert import bdassert@}
+class complex
 	public real as double
 	public img as double
 	public function __init__(real as double, img as double)
@@ -15,8 +16,37 @@
 end
 
 dim a = new complex(1,2), b = new complex(3,4)
-dim c = (a == a+b)##
+dim c = (new complex(4,6) == a+b)
+{@bdassert("c")@}
 
+
+struct complex2
+	public real as double
+	public img as double
+	public function init(real as double, img as double)
+		this.real=real
+		this.img=img
+	end
+	public function __add__ (other as complex2) as complex2
+		dim ret as complex2
+		ret.init(real+other.real,img+other.img)
+		return ret
+	end
+
+	public function __eq__(other as complex2) as boolean
+		return real==other.real && img==other.img
+	end
+end
+
+function mkcomplex2(real as double, img as double) as complex2
+		dim ret as complex2
+		ret.init(real,img)
+		return ret
+end
+
+dim a2 = mkcomplex2(1,2), b2 = mkcomplex2(3,4)
+c = (mkcomplex2(4,6) == a2+b2)
+{@bdassert("c")@}
 
 class vector[T]
 	private buf as T[]
@@ -29,5 +59,8 @@ class vector[T]
 end
 
 dim vec = new vector[int](10)
+vec[2]=132
 dim itm as int = vec[2]
-vec[2]=itm
+{@bdassert("itm==132")@}
+println("Operator tests done")
+

--- a/tests/py_module_test.txt
+++ b/tests/py_module_test.txt
@@ -1,5 +1,3 @@
-package py_module_test
-
 import py_module_test.a
 
 {@

--- a/tests/rtti2.txt
+++ b/tests/rtti2.txt
@@ -1,7 +1,18 @@
 import rtti1:*
+import rtti:get_type_info
+{@from bdassert import bdassert@}
+
+class subcls1 : cls1
+
+end
 
 dim a = new cls1
-println(typeof(a).get_name())
+{@bdassert('''typeof(a).get_name()=="rtti1.cls1" ''')@}
 
 dim b = new cls2[int]
-println(typeof(b).get_name())
+{@bdassert('''typeof(b).get_name()=="rtti1.cls2[int]" ''')@}
+
+dim c = new subcls1
+{@bdassert("get_type_info[cls1]().is_parent_of(typeof(c))")@}
+
+println("RTTI test done!")

--- a/tests/scripttest.py
+++ b/tests/scripttest.py
@@ -112,12 +112,12 @@ dim e = c+d
 
 ''')
 
-
+#tests for member function templates
 assert_generate_ok('''
 class tttt
-	func a[T1,T2,T3](v1 as T2, v2 as T3)
+	public func a[T1,T2,T3](v1 as T2, v2 as T3)
 	end
-	func a[T1](v1 as T1)
+	public func b[T1](v1 as T1)
 	end
 end
 
@@ -128,6 +128,13 @@ p.b[int](1)
 p.b(1.4)
 ''')
 
+#test for binding member functions
+assert_generate_ok('''
+dim a = "asa".length
+dim b as closure () as uint = "asa".length
+''')
+
+#test for "too many template arguments"
 assert_fail('''
 function v[T]()
 end

--- a/tests/scripttest.py
+++ b/tests/scripttest.py
@@ -113,6 +113,27 @@ dim e = c+d
 ''')
 
 
+assert_generate_ok('''
+class tttt
+	func a[T1,T2,T3](v1 as T2, v2 as T3)
+	end
+	func a[T1](v1 as T1)
+	end
+end
+
+dim p as tttt =  new tttt
+p.a[int,float,double](2.3,4.5)
+p.a[int]("s","b")
+p.b[int](1)
+p.b(1.4)
+''')
+
+assert_fail('''
+function v[T]()
+end
+v[int,float]()
+''')
+
 assert_ok('''
 {@set_ast(stmt("declare function getc() as int"))@}
 getc()

--- a/tests/template_link_test.txt
+++ b/tests/template_link_test.txt
@@ -1,10 +1,10 @@
 #gcc -o  tests/bin/template_link_test tests/bin/template_link_test.o tests/bin/template_link_test_lib.o BirdeeHome/bin/blib/birdee.o BirdeeHome/bin/blib/list.o BirdeeHome/bin/blib/hash_map.o lib/libBirdeeRuntime.a  -lgc
 
 import template_link_test_lib
-import hash_map:hash_map
+import hash:hash_map
 
-dim map = new hash_map[string,int]:create()
-map.set("123",321)
+dim map = new hash_map[string,int]()
+map.insert("123",321)
 
 template_link_test_lib.test()
 

--- a/tests/template_link_test_lib.txt
+++ b/tests/template_link_test_lib.txt
@@ -1,8 +1,8 @@
-import hash_map:hash_map
+import hash:hash_map
 
 function test()
-	dim a = new hash_map[string,int]:create()
-	a.set("123",add[int](21,23))
+	dim a = new hash_map[string,int]()
+	a.insert("123",add[int](21,23))
 end
 
 function add[T](a as T, b as T) as T

--- a/tests/test_package/a/mod1.txt
+++ b/tests/test_package/a/mod1.txt
@@ -1,5 +1,11 @@
 package test_package.a
 
-function funct()
-	println("HAHA")
+class some_class
+	public b as float
+	public func __init__(v as float)=> b=v
+	public func get() as float => b
+end
+
+function funct() as string
+	return ("HAHA")
 end

--- a/tests/test_package/b/functype_test_lib.txt
+++ b/tests/test_package/b/functype_test_lib.txt
@@ -1,5 +1,7 @@
 package test_package.b
 
+{@from bdassert import bdassert@}
+
 functype tyfunc(a as int, b as int) as int
 functype tyfunc2(a as int, b as float) as string
 closure closure1(a as int, b as int) as int
@@ -19,11 +21,11 @@ pclosure = pfunc
 
 pclosure = pfunc2
 
-pclosure(1,2)
+{@bdassert("pclosure(1,2)==3")@}
 ##
 
 closure pstradd(other as string) as string
 
 dim stradd as pstradd= "hello".__add__
 
-stradd("hi")
+{@bdassert('''stradd("hi")=="hellohi" ''')@}

--- a/tests/test_package/b/mod2.txt
+++ b/tests/test_package/b/mod2.txt
@@ -1,7 +1,9 @@
 package test_package.b
 
 import test_package.a.mod1:funct
+import test_package.a.mod1:some_class
 import logic_obj_cmp:a
 
+dim v as some_class
 funct()
 println(a)

--- a/tests/threading_test.bdm
+++ b/tests/threading_test.bdm
@@ -1,3 +1,4 @@
+#import functional.closures
 import concurrent.threading:*
 
 function add(a as int, b as int)

--- a/tests/threading_test.bdm
+++ b/tests/threading_test.bdm
@@ -1,10 +1,14 @@
 #import functional.closures
 import concurrent.threading:*
 
+{@from bdassert import bdassert@}
+dim v = 0
 function add(a as int, b as int)
 	println(int2str(a+b))
+	v = a+b
 end
 
 dim th = new thread(add, 1, 2)
-sleep(10000)
+sleep(2000)
 println("end")
+{@bdassert("v==3")@}

--- a/tests/typedptr_test.txt
+++ b/tests/typedptr_test.txt
@@ -1,23 +1,6 @@
 import typedptr:*
 
-@enable_rtti
-class assertion_exception
-
-end
-
-{@
-from bdutils import *
-def line_pos():
-	strpos = str(get_cur_script().pos)
-	set_ast(StringLiteralAST.new(strpos))
-@}
-
-function assert(v as boolean, msg as string)
-	if !v then
-		println("Assertion failed :" + msg)
-		throw new assertion_exception
-	end
-end
+{@from bdassert import bdassert@}
 
 
 struct mystruct
@@ -33,25 +16,25 @@ dim b as int[] = [1,2,3,4]
 dim c as mystruct
 
 dim pa = mkref[int](addressof(a))
-assert(pa.get()==32, {@line_pos()@})
+{@bdassert("pa.get()==32")@}
 
 pa.set(64)
-assert(a==64, {@line_pos()@})
-assert(pa==mkref[int](addressof(a)), {@line_pos()@})
+{@bdassert("a==64")@}
+{@bdassert("pa==mkref[int](addressof(a))")@}
 pa=mkref[int](addressof(a2))
-assert(pa==mkref[int](addressof(a2)), {@line_pos()@})
+{@bdassert("pa==mkref[int](addressof(a2))")@}
 
 pa = mkref[int](addressof(b[0]))
-assert(pa.get()==1, {@line_pos()@})
+{@bdassert("pa.get()==1")@}
 pa = pa + 1
-assert(pa.get()==2, {@line_pos()@})
+{@bdassert("pa.get()==2")@}
 
 c.a=1
 c.b=2
 c.c="sadas"
 dim pc = mkref[mystruct](addressof(c))
-assert(pc.f["a"]()==1, {@line_pos()@})
-assert(pc.fptr["b"]().get()==2, {@line_pos()@})
-assert(pc.f["c"]()=="sadas", {@line_pos()@})
+{@bdassert("pc.f[\"a\"]()==1")@}
+{@bdassert("pc.fptr[\"b\"]().get()==2")@}
+{@bdassert("pc.f[\"c\"]()==\"sadas\"")@}
 println("Should be sadas: " + pc.f["c"]())
 println("test done")


### PR DESCRIPTION
1. Fix the inconsistency of code due to the updates of other parts
2. Correctly use global variables in REPL
3. Feature: option now supports non-reference types
4. Automatically register as destructor parent classes' `__del__` if the function is not defined in current class
5. Correctly generate function link names in bmm files
6. Feature & fix: member functions are now closures: `"a".get_raw` is now a closure instead of a functype.
7. Main function now returns 0
8. Push PyScope for class templates
9. Use make file to compile and run tests 