### PR TITLE
Implement overloading

### DIFF
--- a/Birdee/CopyAST.cpp
+++ b/Birdee/CopyAST.cpp
@@ -314,6 +314,7 @@ namespace Birdee
 		auto ret = make_unique<FunctionAST>(Proto->Copy(), Body.Copy(), nullptr, is_vararg,std::move(vararg_n), Pos);
 		ret->isTemplateInstance = isTemplateInstance;
 		ret->is_extension = is_extension;
+		ret->annotation = annotation;
 		return std::move(ret);
 	}
 
@@ -360,6 +361,7 @@ namespace Birdee
 		clsdef->template_source_class = template_source_class;
 		assert(clsdef->template_instance_args==nullptr);
 		cur_cls = old_cls;
+		clsdef->annotation = annotation;
 		return std::move(clsdef);
 	}
 
@@ -397,7 +399,7 @@ namespace Birdee
 	}
 	MemberFunctionDef Birdee::MemberFunctionDef::Copy()
 	{
-		return MemberFunctionDef(access,unique_ptr_cast<FunctionAST>(decl->Copy()),virtual_idx);
+		return MemberFunctionDef(access,unique_ptr_cast<FunctionAST>(decl->Copy()), std::vector<std::string>(*annotations), virtual_idx, is_abstract);
 	}
 
 	std::unique_ptr<StatementAST> Birdee::ResolvedFuncExprAST::Copy()

--- a/Birdee/MetadataSerializer.cpp
+++ b/Birdee/MetadataSerializer.cpp
@@ -405,6 +405,8 @@ json BuildSingleClassJson(ClassAST& cls, bool dump_qualified_name)
 			auto access = GetAccessModifierName(func.access);
 			json_func["access"] = access;
 			json_func["virtual_idx"] = func.virtual_idx;
+			if (func.is_abstract)
+				json_func["is_abstract"] = true;
 			if (func.decl->isTemplate())
 			{
 				/*for (auto& instance : (func.decl->template_param->instances))

--- a/Birdee/MetadataSerializer.cpp
+++ b/Birdee/MetadataSerializer.cpp
@@ -253,6 +253,8 @@ json BuildFunctionJson(FunctionAST* func)
 		return ret;
 	}
 	ret["name"] = func->GetName();
+	if (func->annotation)
+		ret["annotations"] = *func->annotation;
 	if (!func->Proto->cls && func->isDeclare)
 		ret["link_name"] = func->link_name.empty()? func->GetName(): func->link_name;
 	json args = json::array();
@@ -332,8 +334,8 @@ json BuildGlobalFuncJson(json& func_template)
 			json template_obj;
 			auto ptr = itr.second.first->template_param.get();
 			template_obj["template"] = ptr->source.get();
-			if (ptr->annotation)
-				template_obj["annotations"] = ptr->annotation->anno;
+			if (itr.second.first->annotation)
+				template_obj["annotations"] = *itr.second.first->annotation;
 			template_obj["source_line"] = itr.second.first->Pos.line;
 			template_obj["is_public"] = itr.second.second;
 			template_obj["name"] = itr.second.first->Proto->Name;
@@ -362,6 +364,8 @@ json BuildSingleClassJson(ClassAST& cls, bool dump_qualified_name)
 	json_cls["needs_rtti"] = cls.needs_rtti;
 	json_cls["is_struct"] = cls.is_struct;
 	json_cls["is_interface"] = cls.is_interface;
+	if (cls.annotation)
+		json_cls["annotations"] = *cls.annotation;
 	if (cls.parent_class)
 	{
 		json_cls["parent"] = ConvertClassToIndex(cls.parent_class);
@@ -379,8 +383,6 @@ json BuildSingleClassJson(ClassAST& cls, bool dump_qualified_name)
 		assert(!cls.template_param->source.empty());
 		json_cls["template"] = cls.template_param->source.get();
 		json_cls["source_line"] = cls.Pos.line;
-		if (cls.template_param->annotation)
-			json_cls["annotations"] = cls.template_param->annotation->anno;
 	}
 	else
 	{
@@ -424,8 +426,8 @@ json BuildSingleClassJson(ClassAST& cls, bool dump_qualified_name)
 				}
 				else
 					json_func["template"] = source.get();
-				if (func.decl->template_param->annotation)
-					json_func["annotations"] = func.decl->template_param->annotation->anno;
+				if (func.decl->annotation)
+					json_func["annotations"] = *func.decl->annotation;
 				json_func["source_line"] = func.decl->Pos.line;
 			}
 			else

--- a/Birdee/Preprocessing.cpp
+++ b/Birdee/Preprocessing.cpp
@@ -955,6 +955,41 @@ inline bool IsFunctype(const ResolvedType& v)
 	return v.index_level == 0 && v.type == tok_func && !v.proto_ast->is_closure;
 }
 
+BD_CORE_API bool TypeCanBeConvertedTo(ResolvedType& from, ResolvedType& target)
+{
+	if (target == from)
+	{
+		return true;
+	}
+	if (IsClosure(target) && IsFunctype(from))
+	{
+		//if both types are functions and target is closure & source value is not closure
+		if (target.proto_ast->IsSamePrototype(*from.proto_ast))
+		{
+			return true;
+		}
+	}
+	if (target.isReference() && from.isReference())
+	{
+		if (from.isNull())
+		{
+			return true;
+		}
+		if (IsResolvedTypeClass(from)
+			&& IsResolvedTypeClass(target)) // check for upcast
+		{
+			if (from.class_ast->HasParent(target.class_ast) ||
+				from.class_ast->HasImplement(target.class_ast))
+				return true;
+		}
+	}
+	else if (target.isNumber() && from.isNumber())
+	{
+		return true;
+	}
+	return false;
+}
+
 unique_ptr<ExprAST> FixTypeForAssignment(ResolvedType& target, unique_ptr<ExprAST>&& val,SourcePos pos)
 {
 	if (target == val->resolved_type)

--- a/Birdee/PythonBinding.cpp
+++ b/Birdee/PythonBinding.cpp
@@ -12,6 +12,7 @@ using namespace Birdee;
 
 extern void CompileExpr(char* cmd);
 extern BD_CORE_API Tokenizer tokenizer;
+extern bool TypeCanBeConvertedTo(ResolvedType& from, ResolvedType& target);
 
 namespace Birdee
 {
@@ -108,6 +109,7 @@ void RegisiterClassForBinding2(py::module& m) {
 			return;
 		})
 		.def("__eq__", &ResolvedType::operator ==)
+		.def("is_convertible_to", TypeCanBeConvertedTo)
 		.def("is_integer", &ResolvedType::isInteger);
 	py::class_<ImportedModule>(m, "ImportedModule")
 		.def_readonly("source_dir", &ImportedModule::source_dir)

--- a/Birdee/PythonBinding2.cpp
+++ b/Birdee/PythonBinding2.cpp
@@ -649,7 +649,7 @@ void RegisiterClassForBinding(py::module& m)
 
 	py::class_ < MemberFunctionDef>(m, "MemberFunctionDef")
 		.def_static("new", [](AccessModifier access, UniquePtrStatementAST& v) {
-			return new UniquePtr< MemberFunctionDef>(MemberFunctionDef(access, move_cast_or_throw< FunctionAST>(v.ptr)));
+			return new UniquePtr< MemberFunctionDef>(MemberFunctionDef(access, move_cast_or_throw< FunctionAST>(v.ptr), std::vector<std::string>()));
 		})
 		.def_readwrite("access", &MemberFunctionDef::access)
 		.def_property("decl", [](MemberFunctionDef& ths) {return GetRef(ths.decl); },

--- a/Birdee/include/BdAST.h
+++ b/Birdee/include/BdAST.h
@@ -1051,7 +1051,6 @@ namespace Birdee {
 		map<reference_wrapper<const vector<TemplateArgument>>, unique_ptr<T>> instances;
 		SourceStringHolder source; //no need to copy this field
 		ImportedModule* mod = nullptr;
-		AnnotationStatementAST* annotation = nullptr;
 		/*
 		For classast, it will take the ownership of v. For FunctionAST, it won't
 		*/
@@ -1090,6 +1089,7 @@ namespace Birdee {
 		IntrisicFunction* intrinsic_function = nullptr;
 		string vararg_name;
 		string link_name;
+		vector<string>* annotation = nullptr;
 		std::unique_ptr<PrototypeAST> Proto;
 		//the source template and the template args for the template function instance
 		unique_ptr<vector<TemplateArgument>> template_instance_args;
@@ -1207,6 +1207,7 @@ namespace Birdee {
 		int virtual_idx = -1;
 		// virtual_idx in itable
 		int if_virtual_idx = -1;
+		std::unique_ptr<std::vector<std::string>> annotations;
 		std::unique_ptr<FunctionAST> decl;
 		void print(int level)
 		{
@@ -1219,8 +1220,10 @@ namespace Birdee {
 			decl->print(level);
 		}
 		MemberFunctionDef Copy();
-		MemberFunctionDef(AccessModifier access, std::unique_ptr<FunctionAST>&& decl, int virtual_idx = -1, bool is_abstract = false) :
-			access(access), decl(std::move(decl)), virtual_idx(virtual_idx), is_abstract(is_abstract) {}
+		MemberFunctionDef(AccessModifier access, std::unique_ptr<FunctionAST>&& decl, std::vector<std::string>&& annotations,
+			int virtual_idx = -1, bool is_abstract = false) :
+			access(access), decl(std::move(decl)), virtual_idx(virtual_idx), is_abstract(is_abstract),
+			annotations(std::make_unique<std::vector<std::string>>(std::move(annotations))){}
 	};
 
 	class BD_CORE_API NewExprAST : public ExprAST {
@@ -1261,6 +1264,7 @@ namespace Birdee {
 		bool is_abstract = false;
 		bool is_interface = false;
 		int done_phase = 0;
+		vector<string>* annotation = nullptr;
 		//the table of virtual functions, including the inherited virt functions from parents
 		//valid after Phase0
 		vector<FunctionAST*> vtabledef;

--- a/BirdeeHome/pylib/bdtesting/utils.py
+++ b/BirdeeHome/pylib/bdtesting/utils.py
@@ -1,0 +1,39 @@
+from birdeec import *
+
+def assert_fail(istr):
+	try:
+		top_level(istr)
+		process_top_level()
+		assert(False)
+	except TokenizerException:
+		e=get_tokenizer_error()
+		print(e.linenumber,e.pos,e.msg)
+	except CompileException:
+		e=get_compile_error()
+		print(e.linenumber,e.pos,e.msg)		
+	clear_compile_unit()
+
+def assert_ok(istr):
+	top_level(istr)
+	process_top_level()
+	clear_compile_unit()
+
+def assert_generate_ok(istr):
+	top_level(istr)
+	process_top_level()
+	generate()
+	clear_compile_unit()
+
+def assert_generate_fail(istr):
+	try:
+		top_level(istr)
+		process_top_level()
+		generate()
+		assert(False)
+	except TokenizerException:
+		e=get_tokenizer_error()
+		print(e.linenumber,e.pos,e.msg)
+	except CompileException:
+		e=get_compile_error()
+		print(e.linenumber,e.pos,e.msg)		
+	clear_compile_unit()

--- a/BirdeeHome/pylib/overload.py
+++ b/BirdeeHome/pylib/overload.py
@@ -68,8 +68,12 @@ def overloaded(func):
                 callee = MemberExprAST.new(ThisExprAST.new(), best_matcher[0].impl.proto.name)
             else:
                 callee = ResolvedFuncExprAST.new(best_matcher[0].impl)
-            callexpr = CallExprAST.new(callee, 
+            mycallexpr = CallExprAST.new(callee, 
                 [LocalVarExprAST.new(v) for v in func.proto.args])
+            if func.proto.return_type.base != BasicType.VOID:
+                callexpr = ReturnAST.new(mycallexpr)
+            else:
+                callexpr = mycallexpr
             func.body.push_back(callexpr)
             return
         elif len(best_matcher)>1:

--- a/BirdeeHome/pylib/overload.py
+++ b/BirdeeHome/pylib/overload.py
@@ -1,0 +1,98 @@
+from birdeec import *
+
+class ImplMatcher:
+    def __init__(self, impl, args):
+        self.args = args
+        self.impl = impl
+    
+    def __str__(self):
+        buf = [str(arg) for arg in self.args]
+        return ', '.join(buf)
+    '''
+    Match the args (the actual template parameters of overloaded function) with
+    the registered implementaions in self.
+    Args should be list of TemplateArgument
+    Returns the number of perfect matches of args with self.args, or None if the matching fails
+    '''
+    def match(self, args):
+        if len(args) != len(self.args):
+            return None
+        matches = 0
+        for (slf, tgt) in zip(self.args, args):
+            if tgt.kind == TemplateArgument.TemplateArgumentType.TEMPLATE_ARG_TYPE:
+                if slf != tgt.resolved_type:
+                    #check if the given type can be auto-converted to the registered type
+                    #if true, it is an inperfect match
+                    if not tgt.resolved_type.is_convertible_to(slf):
+                        return None
+                else:
+                    #this is a perfect match
+                    matches+=1
+            else:
+                '''if slf.expr.resolved_type != tgt.expr.resolved_type:
+                    return False
+                if slf.expr.value != tgt.expr.value:
+                    return False'''
+                return None
+        return matches
+_mapping = dict()
+
+def overloaded(func):
+    if len(func.body)!=0:
+        raise RuntimeError("The overloaded function must not have a body")
+    if not func.is_template_instance:
+        raise RuntimeError("The overloaded function must be a function template")
+    templfunc = func.template_source_func
+    if templfunc in _mapping:
+        matchers = _mapping[templfunc]
+        best_matcher = []
+        best_num_matches = 0
+        for matcher in matchers:
+            _num_matches = matcher.match(func.template_instance_args)
+            if _num_matches:
+                if best_num_matches < _num_matches:
+                    best_num_matches = _num_matches
+                    best_matcher = [matcher]
+                elif best_num_matches == _num_matches:
+                    best_matcher.append(matcher)
+        if len(best_matcher)==1:
+            callexpr = CallExprAST.new(ResolvedFuncExprAST.new(best_matcher[0].impl), 
+                [LocalVarExprAST.new(v) for v in func.proto.args])
+            func.body.push_back(callexpr)
+            return
+        elif len(best_matcher)>1:
+            curparams=', '.join([str(v.resolved_type) for v in func.proto.args])
+            candidates='\n'.join(["{} @ {}".format(m, m.impl.pos) for m in best_matcher])
+            raise RuntimeError("The overloaded function {} with parameter types ({}) has ambiguous overloading candidates:\n{}".format(
+                templfunc.proto.name, curparams, candidates))
+    raise RuntimeError("Cannot overload function {} with parameter types ({})".format(templfunc.proto.name,
+        ', '.join([str(v.resolved_type) for v in func.proto.args])))
+
+def overloading_with(target_name, *args):
+    def rfunc(func):
+        iden = IdentifierExprAST.new(target_name)
+        thefunc = iden.get().impl
+        if not isinstance(thefunc, ResolvedFuncExprAST):
+            raise RuntimeError("The overloading target {} is not a function definition".format(target_name))
+        resolved_args = []
+        for arg in args:
+            if isinstance(arg, str):
+                resolved_args.append(resolve_type(arg))
+            elif isinstance(arg, ResolvedType):
+                resolved_args.append(arg)
+            else:
+                raise RuntimeError("The annotation 'overloading' only accept str or ResolvedType as type arguments")
+
+        thefunc = thefunc.funcdef
+        if thefunc not in _mapping:
+            _mapping[thefunc] = []
+        _mapping[thefunc].append(ImplMatcher(func, resolved_args))
+    return rfunc
+
+def overloading(target_name):
+    def run(func):
+        args=[arg.resolved_type for arg in func.proto.args]
+        overloading_with(target_name, *args)(func)
+    return run
+
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,7 +11,7 @@ all:${TEST_BIN_DIR} dlltest autoclose_test.test array_literal.test interface_tes
     import_test.test json_test.test logic_obj_cmp.test net_test.ttest operators.test \
 	rtti2.test string_test.test template_link_test.test threading_test.ttest threadpool_test.ttest threadlocal_test.ttest typedptr_test.test\
 	vector_test.test reflection_test.test unary_op_test.test \
-	ast_write_test.pytest scripttest.pytest template_vararg.pytest getset_test.pytest \
+	ast_write_test.pytest scripttest.pytest template_vararg.pytest getset_test.pytest overloadtest.pytest \
 	py_module_test.module
 
 

--- a/tests/import_test.txt
+++ b/tests/import_test.txt
@@ -7,8 +7,9 @@ dim o = new test_package.a.mod1.some_class(2.3)
 o.templ(2)
 o.templ(2.2)
 
-test_package.a.mod1.add(1,"asd")
+dim v=test_package.a.mod1.add(1,"asd")
 
+{@bdassert('v=="1asd"')@}
 {@bdassert("o.b==2.3")@}
 {@bdassert("o.get()==2.3")@}
 {@bdassert("test_package.a.mod1.funct()==\"HAHA\"")@}

--- a/tests/import_test.txt
+++ b/tests/import_test.txt
@@ -3,6 +3,12 @@ import test_package.a.mod1
 
 {@from bdassert import bdassert@}
 dim o = new test_package.a.mod1.some_class(2.3)
+
+o.templ(2)
+o.templ(2.2)
+
+test_package.a.mod1.add(1,"asd")
+
 {@bdassert("o.b==2.3")@}
 {@bdassert("o.get()==2.3")@}
 {@bdassert("test_package.a.mod1.funct()==\"HAHA\"")@}

--- a/tests/makefile2.mak
+++ b/tests/makefile2.mak
@@ -4,7 +4,7 @@ all: $(OUT_DIR) dlltest autoclose_test.test array_literal.test interface_test.te
     import_test.test json_test.test logic_obj_cmp.test net_test.ntest operators.test \
 	rtti2.test string_test.test template_link_test.test threading_test.test threadpool_test.test threadlocal_test.test typedptr_test.test \
 	vector_test.test reflection_test.test unary_op_test.test \
-	ast_write_test.pytest scripttest.pytest template_vararg.pytest getset_test.pytest \
+	ast_write_test.pytest scripttest.pytest template_vararg.pytest getset_test.pytest overloadtest.pytest \
 	py_module_test.module
 SRC_DIR=.
 OUT_DIR=bin

--- a/tests/overloadtest.py
+++ b/tests/overloadtest.py
@@ -1,7 +1,25 @@
 from bdtesting.utils import *
-#import birdeec
+import birdeec
 
 #birdeec.set_print_ir(True)
+assert_generate_ok('''
+{@from overload import *@}
+class AAA
+	@overloaded
+	public func add[T1,T2](a as T1, b as T2)
+	end
+
+	@overloading("add")
+	func myadd(a as int, b as string)
+		println(int2str(a)+b)
+	end
+end
+{@print("HHHH")@}
+dim t = new AAA
+t.add(2,"3")
+''')
+
+
 assert_generate_ok('''
 {@from overload import *@}
 

--- a/tests/overloadtest.py
+++ b/tests/overloadtest.py
@@ -1,0 +1,144 @@
+from bdtesting.utils import *
+#import birdeec
+
+#birdeec.set_print_ir(True)
+assert_generate_ok('''
+{@from overload import *@}
+
+@overloaded
+func add[T1,T2](a as T1, b as T2)
+end
+
+@overloading("add")
+func myadd(a as int, b as string)
+	println(int2str(a)+b)
+end
+
+@overloading("add")
+func myadd2(a as string, b as string)
+	println(a+b)
+end
+
+@overloading("add")
+func myadd3(a as string, b as float)
+	println(a+double2str(b))
+end
+
+@overloading("add")
+func myadd4(a as string, b as int)
+	println(a+int2str(b))
+end
+
+@overloading_with("add", "boolean", "boolean")
+func myaddbool(a as boolean, b as boolean)
+	println("BOOOL")
+end
+
+
+{@
+def match_checker(name):
+	def run(expr):
+		assert(expr.callee.funcdef.body[0].callee.funcdef.proto.name==name)
+	return run
+@}
+
+@match_checker("myadd")
+add(1,"asds")
+
+@match_checker("myadd2")
+add("ds", "sa")
+
+@match_checker("myadd3")
+add("ddd", 1.2)
+
+@match_checker("myaddbool")
+add(true, false)
+
+#inperfect match
+@match_checker("myadd")
+add(1.2,"asds")
+
+#select better match instead of inperfect one
+@match_checker("myadd4")
+add("asds", 1)
+
+@overloaded
+func addany[...](...)
+end
+
+@overloading("addany")
+func addany1(a as string, b as string)
+	println(a+b)
+end
+@match_checker("addany1")
+addany("1", "2")
+''')
+
+#ambiguous overloading
+assert_fail('''
+{@from overload import *@}
+
+@overloaded
+func add[T1,T2](a as T1, b as T2)
+end
+
+@overloading("add")
+func myadd1(a as int, b as string)
+	println(int2str(a)+b)
+end
+
+@overloading("add")
+func myadd2(a as double, b as string)
+	println(int2str(a)+b)
+end
+add(1.23f, "sa")
+''')
+
+#no matching overload
+assert_fail('''
+{@from overload import *@}
+
+@overloaded
+func add[T1,T2](a as T1, b as T2)
+end
+
+@overloading("add")
+func myadd(a as int, b as string)
+	println(int2str(a)+b)
+end
+add("ds", "sa")
+''')
+
+
+#have a body
+assert_fail('''
+{@from overload import *@}
+
+@overloaded
+func add[T1,T2](a as T1, b as T2)
+	println("HELLO")
+end
+
+@overloading("add")
+func myadd(a as int, b as string)
+	println(int2str(a)+b)
+end
+add(1, "sa")
+''')
+
+#not template
+assert_fail('''
+{@from overload import *@}
+@overloaded
+func add()
+end
+''')
+
+#overloading a variable
+assert_fail('''
+{@from overload import *@}
+dim aaa as int
+@overloading("aaa")
+func add()
+end
+''')

--- a/tests/scripttest.py
+++ b/tests/scripttest.py
@@ -6,6 +6,54 @@ set_print_ir(False)
 
 print("The OS name is ", get_os_name(), ". The target bit width is ", get_target_bits())
 
+assert_ok('''
+{@
+annotated=[]
+def some(f):
+	print(f.proto.name)
+	annotated.append(f.proto.name)
+@}
+class AAA
+	@some
+	public func asd()
+	end
+
+	@some
+	public func asd2[T]()
+	end
+end
+
+dim t = new AAA
+t.asd2[int]()
+
+{@
+assert(annotated[0]=="asd")
+assert(annotated[1]=="asd2[int]")
+@}
+''')
+
+assert_fail('''
+{@def some(f):
+	print(f.proto.name)@}
+
+class AAA
+	@some
+	abstract func bbb()
+end
+@}
+''')
+
+assert_fail('''
+{@def some(f):
+	print(f.proto.name)@}
+
+class AAA
+	@some
+	public a as int
+end
+@}
+''')
+
 assert_generate_ok('''
 class AAA
 	@volatile

--- a/tests/scripttest.py
+++ b/tests/scripttest.py
@@ -1,43 +1,6 @@
 from birdeec import *
+from bdtesting.utils import * 
 import os
-
-def assert_fail(istr):
-	try:
-		top_level(istr)
-		process_top_level()
-		assert(False)
-	except TokenizerException:
-		e=get_tokenizer_error()
-		print(e.linenumber,e.pos,e.msg)
-	except CompileException:
-		e=get_compile_error()
-		print(e.linenumber,e.pos,e.msg)		
-	clear_compile_unit()
-
-def assert_ok(istr):
-	top_level(istr)
-	process_top_level()
-	clear_compile_unit()
-
-def assert_generate_ok(istr):
-	top_level(istr)
-	process_top_level()
-	generate()
-	clear_compile_unit()
-
-def assert_generate_fail(istr):
-	try:
-		top_level(istr)
-		process_top_level()
-		generate()
-		assert(False)
-	except TokenizerException:
-		e=get_tokenizer_error()
-		print(e.linenumber,e.pos,e.msg)
-	except CompileException:
-		e=get_compile_error()
-		print(e.linenumber,e.pos,e.msg)		
-	clear_compile_unit()
 
 set_print_ir(False)
 

--- a/tests/test_package/a/mod1.txt
+++ b/tests/test_package/a/mod1.txt
@@ -19,15 +19,14 @@ class some_class
 	end
 end
 
-
 @overloaded
-func add[T1,T2](a as T1, b as T2)
+func add[T1,T2](a as T1, b as T2) as T2
 end
 
 @preserve
 @overloading("add")
-func myadd(a as int, b as string)
-	println(int2str(a)+b)
+func myadd(a as int, b as string) as string
+	return (int2str(a)+b)
 end
 
 function funct() as string

--- a/tests/test_package/a/mod1.txt
+++ b/tests/test_package/a/mod1.txt
@@ -1,9 +1,33 @@
 package test_package.a
 
+@init_script
+@init_script
+{@from overload import *@}
 class some_class
 	public b as float
 	public func __init__(v as float)=> b=v
 	public func get() as float => b
+
+	@preserve
+	@overloading("templ")
+	public func asd(v as int)
+	end
+
+	@overloaded
+	public func templ[T](g as T)
+
+	end
+end
+
+
+@overloaded
+func add[T1,T2](a as T1, b as T2)
+end
+
+@preserve
+@overloading("add")
+func myadd(a as int, b as string)
+	println(int2str(a)+b)
 end
 
 function funct() as string


### PR DESCRIPTION
 * Implement function overloading, which works on class methods and normal functions

```vb
{@from overload import *@}

@overloaded
func hello[T](b as T)
   #empty body
end

@preserve
@overloading("hello")
func hello_int(b as int)
    println(int2str(b))
end

@preserve
@overloading("hello")
func hello_str(b as string)
    println(b)
end

hello(1.2) #to hello_int
hello(1) #to hello_int
hello("aaa") #to hello_str
```

The overloading will check if the paramter is convertible to the overloading function's paramater.

 * Add `@preserve` annotation to preserve the annotation in compiled BMM file. The annotation will be run on the annotated function when the module is imported. This functionality is used to run "overloading" annotation when the module is imported.

 * Allow Python annotations on member functions
 * Bug fix: export `is_abstract` field of member functions in BMM files. The strange thing is how the commits before this PR works without correctly remembering `is_abstract` field. @huanghaixin008 