### PR TITLE
Parser enhancement, bug fix and library enhancement

### DIFF
--- a/Birdee/Parser.cpp
+++ b/Birdee/Parser.cpp
@@ -1565,6 +1565,7 @@ void ParseClassInPlace(ClassAST* ret, bool is_struct, bool is_interface)
 				tokenizer.GetNextToken(); // eat comma
 			}
 		}
+		ret->needs_rtti = true;
 	}
 	
 	CompileExpect(tok_newline, "Expected newline or inheritance keyword after class name");

--- a/Birdee/include/Tokenizer.h
+++ b/Birdee/include/Tokenizer.h
@@ -135,10 +135,8 @@ namespace Birdee
 		static  std::map<int, Token> single_token_map;
 		static  std::map < std::string, Token > token_map;
 		std::string IdentifierStr; // Filled in if tok_identifier
-
-
-
-		/// gettok - Return the next token from standard input.
+		bool skip_newline = false;  // we allow skipping new line tokens after , and (
+		// gettok - Return the next token from standard input.
 		Token gettok();
 
 	};

--- a/BirdeeHome/src/rtti.bdm
+++ b/BirdeeHome/src/rtti.bdm
@@ -67,3 +67,24 @@ end
 function as_instance[T1,T2](ptr as T2) as option[T1]
 	return some(dyn_cast[T1,T2](ptr))
 end
+
+function match_call[T, T1](val as T, f as closure(v as T1)) as boolean
+	dim ptr = dyn_cast[T1](val)
+	if ptr !== null then
+		f(ptr)
+		return true
+	end
+	return false
+end
+
+function match[T, ...](val as T, ...) as boolean
+{@
+func = get_cur_func()
+args = func.proto.args
+for i in range(1, len(args)):
+	bdutils.set_stmt('''if match_call(val, {}) then
+	return true
+end'''.format(args[i].name))
+@}
+	return false
+end

--- a/tests/interface_test.txt
+++ b/tests/interface_test.txt
@@ -49,7 +49,6 @@ class quail : bird implements itest
 	end
 end
 
-@enable_rtti
 class sparrow implements itest2, itest3[int, string]
 	public func a() as string
 		return "sparrow itest a"

--- a/tests/rtti2.txt
+++ b/tests/rtti2.txt
@@ -6,6 +6,14 @@ class subcls1 : cls1
 
 end
 
+class sub2cls1 : cls1
+
+end
+
+class sub3cls1 : cls1
+
+end
+
 dim a = new cls1
 {@bdassert('''typeof(a).get_name()=="rtti1.cls1" ''')@}
 
@@ -14,5 +22,19 @@ dim b = new cls2[int]
 
 dim c = new subcls1
 {@bdassert("get_type_info[cls1]().is_parent_of(typeof(c))")@}
+
+dim d as cls1 = new sub3cls1
+dim match_num=0
+dim matched = rtti.match(d,
+    func (v as subcls1)
+        throw new runtime_exception("ERROR")
+    end,
+    func (v as sub2cls1)
+        throw new runtime_exception("ERROR")
+    end,
+    func (v as sub3cls1)
+        match_num = 1
+    end)
+{@bdassert("matched && match_num == 1")@}
 
 println("RTTI test done!")

--- a/tests/scripttest.py
+++ b/tests/scripttest.py
@@ -7,6 +7,17 @@ set_print_ir(False)
 print("The OS name is ", get_os_name(), ". The target bit width is ", get_target_bits())
 
 assert_ok('''
+func add(a as int,
+	b as int) as int
+	return a+b
+end
+
+add(
+	12,
+	3)
+''')
+
+assert_ok('''
 {@
 annotated=[]
 def some(f):


### PR DESCRIPTION
# Allow breaking long line after "(" and ","
The parser now allows a new line after "(" or "," token. Now the following code is legal in Birdee:

```vb
func add(a as int,
    b as int) as int
        return a+b
end

add(get_intput(),
      123)
```

 # Bug fix: set enable_rtti for classes implementing an interface
 
 # Add pattern matching as a library function in `rtti.match`

`rtti.match` takes an object with rtti as input, along with several closures. The closures should have signature:

`closure (v as TYPE)`, where the `TYPE` is the type to match for the input object.

```
dim d as cls1 = new sub3cls1
dim match_num=0
dim matched = rtti.match(d,
    func (v as subcls1)
        throw new runtime_exception("ERROR")
    end,
    func (v as sub2cls1)
        throw new runtime_exception("ERROR")
    end,
    func (v as sub3cls1)
        match_num = 1
    end)
```